### PR TITLE
WIP: Rails 5 API controller support

### DIFF
--- a/lib/activerecord-multi-tenant/controller_extensions.rb
+++ b/lib/activerecord-multi-tenant/controller_extensions.rb
@@ -2,7 +2,9 @@ module MultiTenant
   module ControllerExtensions
     def set_current_tenant_through_filter
       self.class_eval do
-        helper_method :current_tenant
+        if respond_to?(:helper_method)
+          helper_method :current_tenant
+        end
 
         private
           def set_current_tenant(current_tenant_object)
@@ -19,4 +21,8 @@ end
 
 if defined?(ActionController::Base)
   ActionController::Base.extend MultiTenant::ControllerExtensions
+end
+
+if defined?(ActionController::API)
+  ActionController::API.extend MultiTenant::ControllerExtensions
 end

--- a/spec/activerecord-multi-tenant/controller_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/controller_extensions_spec.rb
@@ -16,7 +16,32 @@ class ApplicationController < ActionController::Base
   end
 end
 
+class APIApplicationController < ActionController::API
+  include Rails.application.routes.url_helpers
+  set_current_tenant_through_filter
+  before_action :your_method_that_finds_the_current_tenant
+
+  def your_method_that_finds_the_current_tenant
+    current_account = Account.new
+    current_account.name = 'account1'
+    set_current_tenant(current_account)
+  end
+end
+
 describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render body: 'custom called'
+    end
+  end
+
+  it 'Finds the correct tenant using the filter command' do
+    get :index
+    expect(MultiTenant.current_tenant.name).to eq 'account1'
+  end
+end
+
+describe APIApplicationController, type: :controller do
   controller do
     def index
       render body: 'custom called'


### PR DESCRIPTION
In order to better support Rails 5 and specifically Rails 5 in API mode, the ControllerExtensions were modified to also extend ActionController::API. The `helper_method` method in ActionController is also deprecated in Rails 5, so there needs to be some other way of adding the `current_tenant` helper method.

I was in a bit of a hurry so haven't figured out how to run the specs for this, so I haven't been able to test these changes. Lemme know how to get them going and I'll finish out the specs.