### PR TITLE
Do not require tenant model class to be defined; multi_tenant inheritance to subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ end
 
 * **What if I have a table that doesn't relate to my tenant?** (e.g. templates that are the same in every account)
 
-  We recommend not using activerecord-multi-tenant on these tables. In case only some records in a table are not associated to a tenant (i.e. your templates are in the same table as actual objects), we recommend setting the tenant_id to 0, and then using MultiTenant.with_id(0) to access these objects.
+  We recommend not using activerecord-multi-tenant on these tables. In case only some records in a table are not associated to a tenant (i.e. your templates are in the same table as actual objects), we recommend setting the tenant_id to 0, and then using MultiTenant.with(0) to access these objects.
+
+* **What if my tenant model is not defined in my application?**
+
+  The tenant model does not have to be defined. Use the gem as if the model was present. `MultiTenant.with` accepts either a tenant id or model instance.
 
 ## Credits
 

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -32,8 +32,8 @@ module MultiTenant
 
   def self.with(tenant, &block)
     return block.call if self.current_tenant == tenant
+    old_tenant = self.current_tenant
     begin
-      old_tenant = self.current_tenant
       self.current_tenant = tenant
       return block.call
     ensure

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -11,6 +11,10 @@ module MultiTenant
     @@tenant_klass
   end
 
+  def self.tenant_klass_defined?
+    tenant_klass.to_s.classify.safe_constantize.present?
+  end
+
   def self.partition_key
     "#{@@tenant_klass.to_s}_id"
   end

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -1,22 +1,12 @@
 require 'request_store'
 
 module MultiTenant
-  @@tenant_klass = nil
-
-  def self.set_tenant_klass(klass)
-    @@tenant_klass = klass
+  def self.tenant_klass_defined?(tenant_name)
+    !!tenant_name.to_s.classify.safe_constantize
   end
 
-  def self.tenant_klass
-    @@tenant_klass
-  end
-
-  def self.tenant_klass_defined?
-    tenant_klass.to_s.classify.safe_constantize.present?
-  end
-
-  def self.partition_key
-    "#{@@tenant_klass.to_s}_id"
+  def self.partition_key(tenant_name)
+    "#{tenant_name.to_s}_id"
   end
 
   # Workaroud to make "with_lock" work until https://github.com/citusdata/citus/issues/1236 is fixed
@@ -32,43 +22,28 @@ module MultiTenant
     RequestStore.store[:current_tenant]
   end
 
-  def self.current_tenant_id=(tenant_id)
-    self.current_tenant = TenantIdWrapper.new(id: tenant_id)
+  def self.current_tenant_id
+    current_tenant_is_id? ? current_tenant : current_tenant.try(:id)
   end
 
-  def self.current_tenant_id
-    current_tenant.try(:id)
+  def self.current_tenant_is_id?
+    current_tenant.is_a?(String) || current_tenant.is_a?(Integer)
   end
 
   def self.with(tenant, &block)
-    old_tenant = self.current_tenant
-    self.current_tenant = tenant
-    value = block.call
-    return value
-
-  ensure
-    self.current_tenant = old_tenant
-  end
-
-  def self.with_id(tenant_id, &block)
-    if MultiTenant.current_tenant_id == tenant_id
-      block.call
-    else
-      MultiTenant.with(TenantIdWrapper.new(id: tenant_id), &block)
+    return block.call if self.current_tenant == tenant
+    begin
+      old_tenant = self.current_tenant
+      self.current_tenant = tenant
+      return block.call
+    ensure
+      self.current_tenant = old_tenant
     end
   end
+
+  # Preserve backward compatibility for people using .with_id
+  singleton_class.send(:alias_method, :with_id, :with)
 
   class TenantIsImmutable < StandardError
-  end
-
-  class TenantIdWrapper
-    attr_reader :id
-
-    def initialize(id:)
-      @id = id
-    end
-
-    def new_record?; true; end
-    def touch; nil; end
   end
 end

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -160,6 +160,24 @@ describe MultiTenant do
     it 'has primary key' do
       expect(StiSubTask.primary_key).to eq 'id'
     end
+
+    it 'handles belongs_to through' do
+      MultiTenant.with(account) do
+        expect(sti_task.project).to eq project
+      end
+    end
+
+    it 'handles has_many through' do
+      MultiTenant.with(account) do
+        expect(project.sub_tasks).to eq [sti_task]
+      end
+    end
+
+    it 'handles unscoped' do
+      MultiTenant.with(account) do
+        expect(StiSubTask.unscoped.find(sti_task.id)).to eq sti_task
+      end
+    end
   end
 
   # ::with

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -137,6 +137,22 @@ describe MultiTenant do
     end
   end
 
+  describe 'Subclass of Multi Tenant Model' do
+    let(:account) { Account.create!(name: 'foo') }
+    let(:project) { Project.create!(name: 'project', account: account) }
+    let(:task) { project.tasks.create!(name: 'task') }
+    let(:sti_task) { StiSubTask.create!(task: task, name: 'sub task') }
+
+    it 'has partition key' do
+      expect(StiSubTask.partition_key).to eq 'account_id'
+      expect(StiSubTask.instance_variable_get(:@partition_key)).to eq 'account_id'
+    end
+
+    it 'has primary key' do
+      expect(StiSubTask.primary_key).to eq 'id'
+    end
+  end
+
   # ::with
   describe "::with" do
     it "should set current_tenant to the specified tenant inside the block" do

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -56,6 +56,15 @@ describe MultiTenant do
     it { expect(@custom_partition_key_task.account).to eq(@account) }
   end
 
+  describe 'Tenant model not defined' do
+    before do
+      MultiTenant.current_tenant = 77
+      @partition_key_not_model_task = PartitionKeyNotModelTask.create! name: 'foo'
+    end
+
+    it { expect(@partition_key_not_model_task.non_model_id).to be 77 }
+  end
+
   # Scoping models
   describe 'Project.all should be scoped to the current tenant if set' do
     before do
@@ -77,7 +86,7 @@ describe MultiTenant do
     before do
       @account = Account.create! name: 'foo'
       @project = @account.projects.create! name: 'foobar'
-      MultiTenant.current_tenant= @account1
+      MultiTenant.current_tenant = @account1
     end
 
     it { @project.account }

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -28,6 +28,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :account_id, :integer
     t.column :name, :string
     t.column :task_id, :integer
+    t.column :type, :string
   end
 
   create_table :countries, force: true do |t|
@@ -102,6 +103,9 @@ class SubTask < ActiveRecord::Base
   multi_tenant :account
   belongs_to :task
   has_one :project, through: :task
+end
+
+class StiSubTask < SubTask
 end
 
 class UnscopedModel < ActiveRecord::Base

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -56,6 +56,11 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :commentable_type, :string
   end
 
+  create_table :partition_key_not_model_tasks, force: true, partition_key: :non_model_id do |t|
+    t.column :non_model_id, :integer
+    t.column :name, :string
+  end
+
   create_distributed_table :accounts, :id
   create_distributed_table :projects, :account_id
   create_distributed_table :managers, :account_id
@@ -64,6 +69,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :aliased_tasks, :account_id
   create_distributed_table :custom_partition_key_tasks, :accountID
   create_distributed_table :comments, :account_id
+  create_distributed_table :partition_key_not_model_tasks, :non_model_id
 end
 
 class Account < ActiveRecord::Base
@@ -125,6 +131,10 @@ class CustomPartitionKeyTask < ActiveRecord::Base
   else
     validates_uniqueness_of :name, scope: [:account]
   end
+end
+
+class PartitionKeyNotModelTask < ActiveRecord::Base
+  multi_tenant :non_model
 end
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
This PR addresses 2 issues we came across using this gem:
1. The gem requires a tenant model class to exist due to it implicitly setting up a belongs_to relationship. However, our application does not include a tenant model, and we didn't want to have to create a dummy Tenant class just to use this gem
2. The model extensions could not be inherited by subclasses. As we make heavy use of Rails single table inheritance, and in Rails 5 it is common have an ApplicationRecord (abstract model superclass), this limitation meant we had to add `multi_tenant :tenant` in every model, which seemed like a bug.

With this PR, the model extensions check for existence of a model class before defining a belongs_to association and tenant getters/setters. The `MultiTenant.with` method now accepts either a tenant model instance or a tenant_id (Integer or String). In addition, the multi_tenant model extensions will load in any subclasses as expected (minus the automatic association validations, for now).