### PR TITLE
Rails::VERSION and primary_keys

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -21,7 +21,7 @@ module MultiTenant
           # Avoid primary_key errors when using composite primary keys (e.g. id, tenant_id)
           def primary_key
             return @primary_key if @primary_key
-            return @primary_key = super || DEFAULT_ID_FIELD if Rails::VERSION::MAJOR < 5
+            return @primary_key = super || DEFAULT_ID_FIELD if ActiveRecord::VERSION::MAJOR < 5
 
             primary_object_keys = (connection.schema_cache.primary_keys(table_name) || []) - [partition_key]
             if primary_object_keys.size == 1
@@ -45,7 +45,7 @@ module MultiTenant
           if MultiTenant.current_tenant_id
             where(arel_table[partition_key].eq(MultiTenant.current_tenant_id))
           else
-            Rails::VERSION::MAJOR < 4 ? scoped : all
+            ActiveRecord::VERSION::MAJOR < 4 ? scoped : all
           end
         }
 

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -23,7 +23,7 @@ module MultiTenant
             return @primary_key if @primary_key
             return @primary_key = super || DEFAULT_ID_FIELD if ActiveRecord::VERSION::MAJOR < 5
 
-            primary_object_keys = (connection.schema_cache.primary_keys(table_name) || []) - [partition_key]
+            primary_object_keys = ([*connection.schema_cache.primary_keys(table_name)] || []) - [partition_key]
             if primary_object_keys.size == 1
               @primary_key = primary_object_keys.first
             else


### PR DESCRIPTION
So, I've discovered that I somehow missed a few Rails::VERSION instances in #5 

Also I've discovered that on my ActiveRecord (ver 5.0.2) `connection.schema_cache.primary_keys` does not return an array.  Maybe I've mis-configured something though?

At any rate I made a change that uses the poorly known `*` operator to force value to be an array if it's not already one.  If you think that's a bit too obtuse I can rework to use `is_a?(Array)` 