### PR TITLE
preload relation to preserve rails autoloader

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -23,11 +23,14 @@ class TTTenantVisitor < Arel::Visitors::DepthFirst
   private
 
   def tenant_relation?(table)
-    model = table.name.classify.constantize
+    model = table.name.classify.safe_constantize
     model && model.respond_to?(:scoped_by_tenant?) && model.scoped_by_tenant?
   end
 end
 
+
+require 'active_record/relation'
+require 'active_record/relation/query_methods'
 module ActiveRecord
   module QueryMethods
     alias :build_arel_orig :build_arel


### PR DESCRIPTION
fixes bug detailed in #10 

I also hit this when attempting to upgrade to 0.5

I discovered it's caused by the new `query_rewriter`.  it sets up `ActiveRecord::QueryMethods` before the `active_record/relation` file loads, so that when it  does load the rails autoloader no longer loads `active_record/relation/query_methods.rb` because `ActiveRecord::QueryMethods` is already defined.

However!  I'm hitting a different bug now that's caused by the `model = table.name.classify.constantize` in the `tenant_relation?` method.  Some of my models are namespaced, which causes their name to not match the table name, causing that line to throw `uninitialized constant` errors.

Not sure the best approach to fixing that yet, but figured I'd submit this in hope's it helps your debugging.

For right now I'm using `safe_constantize`, i'm guessing that was the intent since otherwise the `model && ` check doesn't work 😁 

