### PR TITLE
fix bug in multi_tenant inheritance

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -32,9 +32,14 @@ module MultiTenant
               @primary_key = DEFAULT_ID_FIELD
             end
           end
+
+          def inherited(subclass)
+            MultiTenant.register_multi_tenant_model(subclass.table_name, subclass) if subclass.table_name
+            super
+          end
         end
 
-        MultiTenant.register_multi_tenant_model(table_name, self)
+        MultiTenant.register_multi_tenant_model(table_name, self) if table_name
 
         @partition_key = options[:partition_key] || MultiTenant.partition_key(tenant_name)
         partition_key = @partition_key

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -61,6 +61,11 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
   end
 
+  create_table :subclass_tasks, force: true, partition_key: :non_model_id do |t|
+    t.column :non_model_id, :integer
+    t.column :name, :string
+  end
+
   create_distributed_table :accounts, :id
   create_distributed_table :projects, :account_id
   create_distributed_table :managers, :account_id
@@ -70,6 +75,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :custom_partition_key_tasks, :accountID
   create_distributed_table :comments, :account_id
   create_distributed_table :partition_key_not_model_tasks, :non_model_id
+  create_distributed_table :subclass_tasks, :non_model_id
 end
 
 class Account < ActiveRecord::Base
@@ -135,6 +141,14 @@ end
 
 class PartitionKeyNotModelTask < ActiveRecord::Base
   multi_tenant :non_model
+end
+
+class AbstractTask < ActiveRecord::Base
+  self.abstract_class = true
+  multi_tenant :non_model
+end
+
+class SubclassTask < AbstractTask
 end
 
 class Comment < ActiveRecord::Base


### PR DESCRIPTION
In model_extensions.rb, we are now calling `MultiTenant.register_multi_tenant_model` to identify tables for the query rewriter.

When this was added, this broke subclass inheritance of the `multi_tenant` declaration (in parent or abstract models).

This PR fixes this bug by ensuring `MultiTenant.register_multi_tenant_model` is called for all subclasses.