### PR TITLE
Fixes automatic inverse of on singular associations

### DIFF
--- a/gemfiles/active_record_5.1.gemfile.lock
+++ b/gemfiles/active_record_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -149,4 +149,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.12.5
+   1.15.0

--- a/gemfiles/rails_3.2.gemfile.lock
+++ b/gemfiles/rails_3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -131,4 +131,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/gemfiles/rails_4.0.gemfile.lock
+++ b/gemfiles/rails_4.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -114,4 +114,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/gemfiles/rails_4.1.gemfile.lock
+++ b/gemfiles/rails_4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -119,4 +119,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/gemfiles/rails_4.2.gemfile.lock
+++ b/gemfiles/rails_4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -142,4 +142,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/gemfiles/rails_5.0.gemfile.lock
+++ b/gemfiles/rails_5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -149,4 +149,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.13.6
+   1.15.0

--- a/gemfiles/rails_5.1.gemfile.lock
+++ b/gemfiles/rails_5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    activerecord-multi-tenant (0.5.0)
+    activerecord-multi-tenant (0.6.0)
       rails (>= 3.1)
       request_store (>= 1.0.5)
 
@@ -149,4 +149,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.12.5
+   1.15.0

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -41,7 +41,7 @@ module MultiTenant
 
         # Create an implicit belongs_to association only if tenant class exists
         if MultiTenant.tenant_klass_defined?(tenant_name)
-          belongs_to tenant_name, options.slice(:class_name, :inverse_of).merge(foreign_key: partition_key)
+          belongs_to tenant_name, options.slice(:class_name, :inverse_of).merge(foreign_key: options[:partition_key])
         end
 
         # New instances should have the tenant set

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -259,7 +259,6 @@ describe MultiTenant do
     before do
       @account = Account.create!(name: "reflection tenant")
       @manager = Manager.new(account: @account)
-      puts "\n\n\n\n#{@account.manager.inspect}\n\n\n\n"
       MultiTenant.current_tenant = @account
       @account.update(name: "reflection tenant update")
     end

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -253,4 +253,19 @@ describe MultiTenant do
       end
     end
   end
+
+  # Reflection
+  describe 'with unsaved association' do
+    before do
+      @account = Account.create!(name: "reflection tenant")
+      @manager = Manager.new(account: @account)
+      puts "\n\n\n\n#{@account.manager.inspect}\n\n\n\n"
+      MultiTenant.current_tenant = @account
+      @account.update(name: "reflection tenant update")
+    end
+
+    it "persists the reflected association" do
+      expect(@manager.persisted?).to eq(true)
+    end
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -75,6 +75,7 @@ end
 class Account < ActiveRecord::Base
   multi_tenant :account
   has_many :projects
+  has_one :manager, inverse_of: :account
 end
 
 class Project < ActiveRecord::Base


### PR DESCRIPTION
This changes the call to `belongs_to` to pull the `:foreign_key` option
from the options, instead of defaulting to the foreign_key generated by
the call to `MultiTenant.partition_key(tenant_name)` on line 39. We do
this because passing a foreign key option will disable the automatic
inverse of reflection within ActiveRecord. See the links below for the
lines in ActiveRecord that prevent the automatic inverse calculation
with this option.

By only using this option if passed, it makes the `multi_tenant` call behave more like a standard ActiveRecord `belongs_to` unless you specify a custom partition key for a model. 

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/reflection.rb#L595

and

https://github.com/rails/rails/blob/master/activerecord/lib/active_record/reflection.rb#L671-L676

This fixes #12 