### PR TITLE
Fix Bug preventing FastTruncate from running

### DIFF
--- a/lib/activerecord-multi-tenant/fast_truncate.rb
+++ b/lib/activerecord-multi-tenant/fast_truncate.rb
@@ -15,7 +15,7 @@ module MultiTenant
         FOR t IN SELECT schemaname, tablename FROM pg_tables WHERE schemaname = 'public' AND tablename NOT IN (%s) LOOP
           EXECUTE 'SELECT EXISTS (SELECT * from pg_class c WHERE c.relkind = ''S'' AND c.relname=''' || t.tablename || '_id_seq'')' into seq_exists;
           IF seq_exists THEN
-            EXECUTE 'SELECT last_value != start_value FROM ' || t.tablename || '_id_seq' INTO needs_truncate;
+            EXECUTE 'SELECT is_called FROM ' || t.tablename || '_id_seq' INTO needs_truncate;
           ELSE
             needs_truncate := true;
           END IF;

--- a/spec/activerecord-multi-tenant/fast_truncate_spec.rb
+++ b/spec/activerecord-multi-tenant/fast_truncate_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe MultiTenant::FastTruncate do
+  before(:each) do
+    MultiTenant::FastTruncate.run
+  end
+
+  it "truncates tables that have exactly one row inserted" do
+    Account.create! name: 'foo'
+    expect {
+      MultiTenant::FastTruncate.run
+    }.to change { Account.count }.from(1).to(0)
+  end
+
+  it "truncates tables that have more than one row inserted" do
+    Account.create! name: 'foo'
+    Account.create! name: 'bar'
+
+    expect {
+      MultiTenant::FastTruncate.run
+    }.to change { Account.count }.from(2).to(0)
+  end
+end


### PR DESCRIPTION
If there was exactly one insert on a table fast truncate would not
run. This was caused by how postgres sets last_value = start_value when
that sequence had not been used.