### PR TITLE
Changes to support cross-partition querying with eager_load and distinct

### DIFF
--- a/lib/activerecord-multi-tenant.rb
+++ b/lib/activerecord-multi-tenant.rb
@@ -1,3 +1,5 @@
+require_relative 'arel/subquery'
+require_relative 'arel/visitors/subquery_to_sql'
 if Object.const_defined?(:ActionController)
   require_relative 'activerecord-multi-tenant/controller_extensions'
 end

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -29,6 +29,7 @@ module MultiTenant
     @@multi_tenant_models[table_name.to_s] = model_klass
   end
   def self.multi_tenant_model_for_table(table_name)
+    @@multi_tenant_models ||= {}
     @@multi_tenant_models[table_name.to_s]
   end
 

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -68,6 +68,26 @@ module MultiTenant
     end
   end
 
+  # Use to bypass rewriting of cross partition COUNT(DISTINCT) queries
+  # to use the hll extension to get approximate counts, if enabled
+  def self.with_hll_counts(&block)
+    orig_hll = self.use_hll_counts?
+    begin
+      self.use_hll_counts = true
+      return block.call
+    ensure
+      self.use_hll_counts = orig_hll
+    end
+  end
+
+  def self.use_hll_counts=(bool)
+    RequestStore.store[:hll_counts] = bool
+  end
+
+  def self.use_hll_counts?
+    RequestStore.store[:hll_counts].present?
+  end
+
   # Preserve backward compatibility for people using .with_id
   singleton_class.send(:alias_method, :with_id, :with)
 

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -101,6 +101,7 @@ module MultiTenant
     # However, if the query can be converted into a distinct via GROUP BY
     # We can convert it into SELECT COUNT(*) FROM (... GROUP BY ...)
     if projections.is_a?(Arel::Nodes::Count) && projections.distinct
+      return arel if MultiTenant.use_hll_counts?
       ctx.projections = projections.expressions
       partition_keys = projections.expressions.map do |e|
         model = MultiTenant.multi_tenant_model_for_table(e.try(:relation).try(:name))

--- a/lib/arel/subquery.rb
+++ b/lib/arel/subquery.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Allow creation of a subquery that acts like an Arel::Table so it can be used in joins
+module Arel
+  class Subquery < Table
+    attr_accessor :data_source
+
+    def initialize(data_source, as:, type_caster: nil)
+      super(as, type_caster: type_caster)
+      @data_source = data_source
+    end
+  end
+end

--- a/lib/arel/visitors/subquery_to_sql.rb
+++ b/lib/arel/visitors/subquery_to_sql.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'arel/visitors/reduce'
+
+# Monkey-patch Arel::Visitors::ToSql to support Arel::Subquery
+module Arel
+  module Visitors
+    class ToSql < Arel::Visitors::Reduce
+      def visit_Arel_Subquery(o, collector)
+        collector << '('
+        collector << case o.data_source
+        when String
+          o.data_source
+        when Arel::SelectManager
+          o.data_source.to_sql
+        else
+          o.data_source.to_s
+        end
+        collector << ") #{quote_table_name o.name}"
+      end
+
+      # def visit_Arel_Nodes_Distinct o, collector
+      #   collector << ''
+      # end
+    end
+  end
+end

--- a/lib/arel/visitors/subquery_to_sql.rb
+++ b/lib/arel/visitors/subquery_to_sql.rb
@@ -18,10 +18,6 @@ module Arel
         end
         collector << ") #{quote_table_name o.name}"
       end
-
-      # def visit_Arel_Nodes_Distinct o, collector
-      #   collector << ''
-      # end
     end
   end
 end

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -153,11 +153,67 @@ describe MultiTenant do
     let(:task) { project.tasks.create!(name: 'eager loading test task') }
     let(:sub_task) { task.sub_tasks.create!(name: 'eager loading test sub task') }
 
-    it 'handles table aliases through joins' do
+    before do
       MultiTenant.with(account) do
         sub_task
         manager
+      end
+    end
+
+    it 'handles table aliases through joins' do
+      MultiTenant.with(account) do
         expect(Project.eager_load([{manager: :project}, {tasks: :project}]).first).to eq project
+      end
+    end
+
+    context 'multi-partition eager loading' do
+      let(:account_2) { Account.create!(name: 'bar') }
+      let(:project_2) { Project.create!(name: 'project_2', account: account_2) }
+      let(:manager_2) { Manager.create!(name: 'manager_2', account: account_2, project: project_2) }
+      let(:task_2) { project_2.tasks.create!(name: 'eager loading test task') }
+      let(:sub_task_2) { task_2.sub_tasks.create!(name: 'eager loading test sub task 2') }
+      let(:sub_task_3) { task_2.sub_tasks.create!(name: 'eager loading test sub task 3') }
+      let(:base_relation) do
+        Project.eager_load([{manager: :project}, {tasks: :sub_tasks}]).where(account_id: [account.id, account_2.id])
+      end
+
+      before do
+        MultiTenant.with(account_2) do
+          sub_task_2
+          sub_task_3
+          manager_2
+        end
+      end
+
+      it 'handles table aliases through joins' do
+        rel = base_relation
+        expect(rel.to_a).to eq [project, project_2]
+        expect(rel.to_sql).to eq %[
+          SELECT "projects"."id" AS t0_r0, "projects"."account_id" AS t0_r1, "projects"."name" AS t0_r2,
+          "managers"."id" AS t1_r0, "managers"."account_id" AS t1_r1, "managers"."name" AS t1_r2,
+          "managers"."project_id" AS t1_r3, "projects_managers"."id" AS t2_r0, "projects_managers"."account_id" AS t2_r1,
+          "projects_managers"."name" AS t2_r2, "tasks"."id" AS t3_r0, "tasks"."name" AS t3_r1, "tasks"."account_id"
+          AS t3_r2, "tasks"."project_id" AS t3_r3, "tasks"."completed" AS t3_r4, "sub_tasks"."id" AS t4_r0,
+          "sub_tasks"."account_id" AS t4_r1, "sub_tasks"."name" AS t4_r2, "sub_tasks"."task_id" AS t4_r3,
+          "sub_tasks"."type" AS t4_r4
+          FROM "projects"
+          LEFT OUTER JOIN "managers" ON "managers"."project_id" = "projects"."id"
+          AND "managers"."account_id" = "projects"."account_id"
+          LEFT OUTER JOIN "projects" "projects_managers" ON "projects_managers"."id" = "managers"."project_id"
+          AND "projects_managers"."account_id" = "projects"."account_id"
+          LEFT OUTER JOIN "tasks" ON "tasks"."project_id" = "projects"."id" AND "tasks"."account_id" = "projects"."account_id"
+          LEFT OUTER JOIN "sub_tasks" ON "sub_tasks"."task_id" = "tasks"."id"
+          AND "sub_tasks"."account_id" = "projects"."account_id"
+          WHERE "projects"."account_id" IN (1, 2)
+        ].squish
+      end
+
+      it 'can count across partitions' do
+        expect(base_relation.count).to be 3 # Because of left joins
+      end
+
+      it 'can distinct across partitions' do
+        expect(base_relation.distinct.to_a).to eq [project, project_2]
       end
     end
   end

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -208,8 +208,8 @@ describe MultiTenant do
         ].squish
       end
 
-      it 'can count across partitions' do
-        expect(base_relation.count).to be 3 # Because of left joins
+      it 'can count distinct across partitions' do
+        expect(base_relation.distinct.count).to be 2
       end
 
       it 'can distinct across partitions' do

--- a/spec/lib/arel/subquery_spec.rb
+++ b/spec/lib/arel/subquery_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arel::Subquery do
+  describe 'new' do
+    let(:table) { described_class.new 'SELECT * FROM clients', as: 'users' }
+
+    it 'sets the data_source' do
+      expect(table.data_source).to eq 'SELECT * FROM clients'
+    end
+
+    it 'sets the name with the as attribute' do
+      expect(table.name).to eq 'users'
+    end
+
+    it 'does not set any alias' do
+      expect(table.table_alias).to be_nil
+    end
+  end
+end

--- a/spec/lib/arel/visitors/to_sql_spec.rb
+++ b/spec/lib/arel/visitors/to_sql_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Arel::Visitors::ToSql do
+  let(:connection) { ActiveRecord::Base.connection }
+  let(:visitor) { described_class.new connection }
+  let(:compiled) { visitor.accept(node, Arel::Collectors::SQLString.new).value }
+
+  describe 'with sql' do
+    let(:node) { Arel::Subquery.new('SELECT * FROM "clients"', as: 'users') }
+
+    it 'visits_Arel_Subquery' do
+      expect(compiled).to eq '(SELECT * FROM "clients") "users"'
+    end
+  end
+
+  describe 'with project' do
+    let(:node) do
+      clients = Arel::Table.new(:clients)
+      Arel::Subquery.new(clients.project(Arel.star), as: 'users')
+    end
+
+    it 'visits_Arel_Subquery' do
+      expect(compiled).to eq '(SELECT * FROM "clients") "users"'
+    end
+  end
+end


### PR DESCRIPTION
I don't expect this to get merged in as is as it may be specific to our use cases, but I wanted to post it here in case anyone else runs into these issues...

Say you want to query for users across tenants a, b, and c. Say you also want to get all users.features.

If you do this with `User.includes(:features).where(tenant_id: [a,b])` Rails will make one query for users scoped to tenant ids a and b, then 2 more queries for `features` where `features.user_id IN (all returned user ids without tenant ids)`. The last 2 queries will hit all your shards 😢 😭

Instead, we want to use `User.eager_load(:features).where(tenant_id: [a,b])`, which will load it all in one query targeted at the 2 shards in the where clause.

We also want to support `User.includes(:features).references(:features).where('features.new = true').distinct.count`. This is a COUNT(DISTINCT) that isn't allowed by citus across partitions even though it should technically be able to be pushed down.

To make all these situations work, we need to:

1. Ensure the partition key is added to the left joins created by eager_load
2. Ensure any SELECT foo, bar DISTINCT is rewritten as SELECT foo, bar GROUP BY foo, bar
3. Rewrite SELECT COUNT(DISTINCT users.id) as SELECT COUNT(*) FROM (SELECT ... GROUP BY users.id, users.partition_key)

It's not pretty but it works...