### PR TITLE
Cast attribute name to a string

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -75,7 +75,7 @@ module MultiTenant
       if o.left.is_a?(Arel::Attributes::Attribute)
         table_name = o.left.relation.table_name
         model = MultiTenant.multi_tenant_model_for_table(table_name)
-        @current_context.visited_handled_relation(o.left.relation) if model.present? && o.left.name.to_s == model.partition_key
+        @current_context.visited_handled_relation(o.left.relation) if model.present? && o.left.name.to_s == model.partition_key.to_s
       end
       super(o, *args)
     end

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -75,7 +75,7 @@ module MultiTenant
       if o.left.is_a?(Arel::Attributes::Attribute)
         table_name = o.left.relation.table_name
         model = MultiTenant.multi_tenant_model_for_table(table_name)
-        @current_context.visited_handled_relation(o.left.relation) if model.present? && o.left.name == model.partition_key
+        @current_context.visited_handled_relation(o.left.relation) if model.present? && o.left.name.to_s == model.partition_key
       end
       super(o, *args)
     end


### PR DESCRIPTION
When the validation is run for the following class, it gets the
`account_id` attribute name as a symbol rather than a string, so it ends
up doupble applying the tenancy clause.

```
class Project < ActiveRecord::Base
  multi_tenant :account
  validates_uniqueness_of :name, scope: [:account]
end
```

Generated SQL

```
SELECT  1 AS one FROM "projects" WHERE "projects"."account_id" = 1 AND
("projects"."name" = 'Test' AND "projects"."account_id" = 1) LIMIT 1
```

Expected SQL

```
SELECT  1 AS one FROM "projects" WHERE ("projects"."name" = 'Test' AND
"projects"."account_id" = 1) LIMIT 1
```