### PR TITLE
Add init of @@multi_tenant_models

### DIFF
--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -29,6 +29,7 @@ module MultiTenant
     @@multi_tenant_models[table_name.to_s] = model_klass
   end
   def self.multi_tenant_model_for_table(table_name)
+    @@multi_tenant_models ||= {}
     @@multi_tenant_models[table_name.to_s]
   end
 


### PR DESCRIPTION
This prevents raising an error if the first model referenced after application boot is not distributed.