### PR TITLE
Removing cache for `find_by` queries.

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -112,3 +112,11 @@ end
 if defined?(ActiveRecord::Base)
   ActiveRecord::Base.extend(MultiTenant::ModelExtensionsClassMethods)
 end
+
+class ActiveRecord::Associations::Association
+  alias skip_statement_cache_orig skip_statement_cache?
+  def skip_statement_cache?
+    return true if klass.respond_to?(:scoped_by_tenant?) && klass.scoped_by_tenant?
+    skip_statement_cache_orig
+  end
+end

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -155,11 +155,7 @@ module MultiTenant
     def to_str; to_sql; end
 
     def to_sql(*)
-      if MultiTenant.current_tenant_id
-        tenant_arel.to_sql
-      else
-        '1=1'
-      end
+      tenant_arel.to_sql
     end
 
     private

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -246,3 +246,14 @@ module ActiveRecord
     end
   end
 end
+
+require 'active_record/base'
+module NoFindCacheOnScopedModels
+  def cached_find_by_statement(key, &block)
+    cache = @find_by_statement_cache[connection.prepared_statements]
+    cache.synchronize { cache[key] = nil } if respond_to?(:scoped_by_tenant?) && scoped_by_tenant?
+    super
+  end
+end
+
+ActiveRecord::Base.singleton_class.prepend(NoFindCacheOnScopedModels)

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -333,16 +333,30 @@ describe MultiTenant do
       project2 = Project.create! name: 'Project 2', account: Account.create!(name: 'Account2')
 
       MultiTenant.with(account) do
+        if uses_prepared_statements?
+          project_id = "$1"
+          limit = "$2"
+        else
+          project_id = project.id
+          limit = 1
+        end
         expected_sql = <<-sql.strip
-        SELECT  "projects".* FROM "projects" WHERE "projects"."account_id" = #{account.id} AND "projects"."id" = #{project.id} LIMIT 1
+        SELECT  "projects".* FROM "projects" WHERE "projects"."account_id" = #{account.id} AND "projects"."id" = #{project_id} LIMIT #{limit}
         sql
         expect(Project).to receive(:find_by_sql).with(expected_sql, any_args).and_call_original
         expect(Project.find(project.id)).to eq(project)
       end
 
       MultiTenant.with(nil) do
+        if uses_prepared_statements?
+          project_id = "$1"
+          limit = "$2"
+        else
+          project_id = project2.id
+          limit = 1
+        end
         expected_sql = <<-sql.strip
-        SELECT  "projects".* FROM "projects" WHERE "projects"."id" = #{project2.id} LIMIT 1
+        SELECT  "projects".* FROM "projects" WHERE "projects"."id" = #{project_id} LIMIT #{limit}
         sql
         expect(Project).to receive(:find_by_sql).with(expected_sql, any_args).and_call_original
         expect(Project.find(project2.id)).to eq(project2)

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -342,7 +342,7 @@ describe MultiTenant do
 
       MultiTenant.with(nil) do
         expected_sql = <<-sql.strip
-        SELECT  "projects".* FROM "projects" WHERE 1=1 AND "projects"."id" = #{project2.id} LIMIT 1
+        SELECT  "projects".* FROM "projects" WHERE "projects"."id" = #{project2.id} LIMIT 1
         sql
         expect(Project).to receive(:find_by_sql).with(expected_sql, any_args).and_call_original
         expect(Project.find(project2.id)).to eq(project2)

--- a/spec/activerecord-multi-tenant/record_finding_spec.rb
+++ b/spec/activerecord-multi-tenant/record_finding_spec.rb
@@ -16,4 +16,19 @@ describe MultiTenant, 'Record finding' do
       expect(UuidRecord.find(uuid_record.id)).to be_present
     end
   end
+
+  it 'can use find_bys accurately' do
+    first_tenant = Account.create! name: 'First Tenant'
+    second_tenant = Account.create! name: 'Second Tenant'
+    first_record = first_tenant.projects.create! name: 'identical name'
+    second_record = second_tenant.projects.create! name: 'identical name'
+    MultiTenant.with(first_tenant) do
+      found_record = Project.find_by(name: 'identical name')
+      expect(found_record).to eq(first_record)
+    end
+    MultiTenant.with(second_tenant) do
+      found_record = Project.find_by(name: 'identical name')
+      expect(found_record).to eq(second_record)
+    end
+  end
 end

--- a/spec/database.yml
+++ b/spec/database.yml
@@ -6,6 +6,5 @@ test:
   port: 5600
   pool: 5
   timeout: 5000
-  prepared_statements: false
   variables:
     citus.shard_count: 5

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,4 +42,8 @@ end
 MultiTenantTest::Application.config.secret_token = 'x' * 40
 MultiTenantTest::Application.config.secret_key_base = 'y' * 40
 
+def uses_prepared_statements?
+  ActiveRecord::Base.connection.prepared_statements
+end
+
 require 'schema'


### PR DESCRIPTION
While setting up the gem on an application I encountered issue #29.

I set up a quick fix, which is invalidating the cache when there is a risk of the cache preventing a proper query execution.
This isn't ideal (since we simply lose all cache on `find_by` queries for multi-tenanted models), but it is better than breaking tenant data separation.

I will add a test to check soon.