### PR TITLE
Add `MultiTenant.without`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,4 +169,4 @@ DEPENDENCIES
   thor
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -68,6 +68,17 @@ module MultiTenant
     end
   end
 
+  def self.without(&block)
+    return block.call if self.current_tenant.nil?
+    old_tenant = self.current_tenant
+    begin
+      self.current_tenant = nil
+      return block.call
+    ensure
+      self.current_tenant = old_tenant
+    end
+  end
+
   # Preserve backward compatibility for people using .with_id
   singleton_class.send(:alias_method, :with_id, :with)
 

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -274,6 +274,40 @@ describe MultiTenant do
     end
   end
 
+  # ::without
+  describe "::without" do
+    it "should unset current_tenant inside the block" do
+      @account = Account.create!(:name => 'baz')
+
+      MultiTenant.current_tenant = @account
+      MultiTenant.without do
+        expect(MultiTenant.current_tenant).to eq(nil)
+      end
+    end
+
+    it "should reset current_tenant to the previous tenant once exiting the block" do
+      @account1 = Account.create!(:name => 'foo')
+
+      MultiTenant.current_tenant = @account1
+      MultiTenant.without do
+
+      end
+
+      expect(MultiTenant.current_tenant).to eq(@account1)
+    end
+
+    it "should return the value of the block" do
+      @account1 = Account.create!(:name => 'foo')
+
+      MultiTenant.current_tenant = @account1
+      value = MultiTenant.without do
+        "something"
+      end
+
+      expect(value).to eq "something"
+    end
+  end
+
   describe '.with_lock' do
     it 'supports with_lock blocks inside the block' do
       @account = Account.create!(name: 'foo')


### PR DESCRIPTION
Issue #44 

Helpful in tests and corner cases when cross-tenant queries are needed within a context where a tenant is already set.