### PR TITLE
when table has no primary key, @primary key should not return id

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -25,8 +25,13 @@ module MultiTenant
             return @primary_key if @primary_key
             return @primary_key = super || DEFAULT_ID_FIELD if ::ActiveRecord::VERSION::MAJOR < 5
 
-            primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name)) - [partition_key]
-            if primary_object_keys.size == 1
+            table_primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name))
+            primary_object_keys = table_primary_object_keys - [partition_key]
+
+            if table_primary_object_keys.size == 0 and !connection.schema_cache.columns_hash(table_name).include? DEFAULT_ID_FIELD
+              # table without a primary key and DEFAULT_ID_FIELD is not present in the table
+              @primary_key = nil
+            elsif primary_object_keys.size == 1
               @primary_key = primary_object_keys.first
             else
               @primary_key = DEFAULT_ID_FIELD

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -25,16 +25,15 @@ module MultiTenant
             return @primary_key if @primary_key
             return @primary_key = super || DEFAULT_ID_FIELD if ::ActiveRecord::VERSION::MAJOR < 5
 
-            table_primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name))
-            primary_object_keys = table_primary_object_keys - [partition_key]
+            primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name)) - [partition_key]
 
-            if table_primary_object_keys.size == 0 and !connection.schema_cache.columns_hash(table_name).include? DEFAULT_ID_FIELD
+            if primary_object_keys.size == 1
+              @primary_key = primary_object_keys.first
+            elsif connection.schema_cache.columns_hash(table_name).include? DEFAULT_ID_FIELD
+              @primary_key = DEFAULT_ID_FIELD
+            else
               # table without a primary key and DEFAULT_ID_FIELD is not present in the table
               @primary_key = nil
-            elsif primary_object_keys.size == 1
-              @primary_key = primary_object_keys.first
-            else
-              @primary_key = DEFAULT_ID_FIELD
             end
           end
 

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -23,7 +23,11 @@ module MultiTenant
           # Avoid primary_key errors when using composite primary keys (e.g. id, tenant_id)
           def primary_key
             return @primary_key if @primary_key
-            return @primary_key = super || DEFAULT_ID_FIELD if ::ActiveRecord::VERSION::MAJOR < 5
+
+            if ::ActiveRecord::VERSION::MAJOR < 5
+              @primary_key = super || DEFAULT_ID_FIELD
+              return @primary_key if connection.schema_cache.columns_hash(table_name).include? @primary_key else nil
+            end
 
             primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name)) - [partition_key]
 

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -26,7 +26,7 @@ module MultiTenant
 
             if ::ActiveRecord::VERSION::MAJOR < 5
               @primary_key = super || DEFAULT_ID_FIELD
-              return @primary_key if connection.schema_cache.columns_hash(table_name).include? @primary_key else nil
+              return @primary_key if connection.schema_cache.columns_hash(table_name).include? @primary_key
             end
 
             primary_object_keys = Array.wrap(connection.schema_cache.primary_keys(table_name)) - [partition_key]

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -573,4 +573,14 @@ describe MultiTenant do
       end
     end
   end
+
+  it "test value of RETURNING insert in table with no pkey" do
+    account1 = Account.create(name: 'test1')
+
+    MultiTenant.with(account1) do
+      allowed_place = AllowedPlace.create! name: 'something1'
+
+      project = Project.create! name: 'Project 1'
+    end
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -89,6 +89,12 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :category_id, :integer
   end
 
+
+  create_table :allowed_places, force: true, id: false do |t|
+  t.string :account_id, :integer
+  t.string :name, :string
+  end
+
   create_distributed_table :accounts, :id
   create_distributed_table :projects, :account_id
   create_distributed_table :managers, :account_id
@@ -101,6 +107,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :subclass_tasks, :non_model_id
   create_distributed_table :uuid_records, :organization_id
   create_distributed_table :project_categories, :account_id
+  create_distributed_table :allowed_places, :account_id
   create_reference_table :categories
 end
 
@@ -198,4 +205,9 @@ class ProjectCategory < ActiveRecord::Base
   belongs_to :project
   belongs_to :category
   belongs_to :account
+end
+
+
+class AllowedPlace < ActiveRecord::Base
+  multi_tenant :account
 end


### PR DESCRIPTION
Hi, we have a problem when a customer has a table with no primary key: They get an error :

`Issue 2: PG::UndefinedColumn: ERROR:  column table.id does not exist`

because of 

```
 INSERT INTO "table" ("company_membership_id", "place_id", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"
```

In the `primary_key` function, I checked that there actually is a primary key, and if there is not and `DEFAULT_ID_FIELD` is not in the columns, the `@primary_key = nil` preventing `RETURNING id`.


Here are the results of the tests:

```
D, [2019-07-03T15:39:02.203628 #983] DEBUG -- :    (0.7ms)  SELECT nextval('accounts_id_seq'::regclass)
D, [2019-07-03T15:39:02.212493 #983] DEBUG -- :   Account Create (8.5ms)  INSERT INTO "accounts" ("id") VALUES ($1) RETURNING "id"  [["id", 1]]
D, [2019-07-03T15:39:02.214744 #983] DEBUG -- :    (2.0ms)  COMMIT
D, [2019-07-03T15:39:02.299737 #983] DEBUG -- :    (0.4ms)  BEGIN
D, [2019-07-03T15:39:02.310247 #983] DEBUG -- :   AllowedPlace Create (6.0ms)  INSERT INTO "allowed_places" ("account_id", "name") VALUES ($1, $2)  [["account_id", "1"], ["name", "something1"]]
D, [2019-07-03T15:39:02.313748 #983] DEBUG -- :    (1.6ms)  COMMIT
D, [2019-07-03T15:39:02.314529 #983] DEBUG -- :    (0.4ms)  BEGIN
D, [2019-07-03T15:39:02.316390 #983] DEBUG -- :   Account Load (1.3ms)  SELECT  "accounts".* FROM "accounts" WHERE "accounts"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
D, [2019-07-03T15:39:02.318513 #983] DEBUG -- :   Project Exists (1.5ms)  SELECT  1 AS one FROM "projects" WHERE "projects"."name" = $1 AND "projects"."account_id" = $2 LIMIT $3  [["name", "Project 1"], ["account_id", 1], ["LIMIT", 1]]
D, [2019-07-03T15:39:02.320635 #983] DEBUG -- :   Project Create (1.6ms)  INSERT INTO "projects" ("account_id", "name") VALUES ($1, $2) RETURNING "id"  [["account_id", 1], ["name", "Project 1"]]
D, [2019-07-03T15:39:02.323202 #983] DEBUG -- :    (2.3ms)  COMMIT
```

As you can see, `RETURNING id` is still used when needed but not in the case of database with no primary key.
