### PR TITLE
Ensure current tenant is present before enforcing tenant in update/delete

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -223,7 +223,7 @@ module MultiTenant
     def join_to_update(update, *args)
       update = super(update, *args)
       model = MultiTenant.multi_tenant_model_for_table(update.ast.relation.table_name)
-      if model.present? && !MultiTenant.with_write_only_mode_enabled?
+      if model.present? && !MultiTenant.with_write_only_mode_enabled? && MultiTenant.current_tenant_id.present?
         update.where(MultiTenant::TenantEnforcementClause.new(model.arel_table[model.partition_key]))
       end
       update
@@ -232,7 +232,7 @@ module MultiTenant
     def join_to_delete(delete, *args)
       delete = super(delete, *args)
       model = MultiTenant.multi_tenant_model_for_table(delete.ast.left.table_name)
-      if model.present? && !MultiTenant.with_write_only_mode_enabled?
+      if model.present? && !MultiTenant.with_write_only_mode_enabled? && MultiTenant.current_tenant_id.present?
         delete.where(MultiTenant::TenantEnforcementClause.new(model.arel_table[model.partition_key]))
       end
       delete
@@ -241,7 +241,7 @@ module MultiTenant
     if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 2
       def update(arel, name = nil, binds = [])
         model = MultiTenant.multi_tenant_model_for_table(arel.ast.relation.table_name)
-        if model.present? && !MultiTenant.with_write_only_mode_enabled?
+        if model.present? && !MultiTenant.with_write_only_mode_enabled? && MultiTenant.current_tenant_id.present?
           arel.where(MultiTenant::TenantEnforcementClause.new(model.arel_table[model.partition_key]))
         end
         super(arel, name, binds)
@@ -249,7 +249,7 @@ module MultiTenant
 
       def delete(arel, name = nil, binds = [])
         model = MultiTenant.multi_tenant_model_for_table(arel.ast.left.table_name)
-        if model.present? && !MultiTenant.with_write_only_mode_enabled?
+        if model.present? && !MultiTenant.with_write_only_mode_enabled? && MultiTenant.current_tenant_id.present?
           arel.where(MultiTenant::TenantEnforcementClause.new(model.arel_table[model.partition_key]))
         end
         super(arel, name, binds)

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -15,11 +15,23 @@ describe "Query Rewriter" do
       }.to change { project.reload.name }.from("Project 1").to("New Name")
     end
 
+    it "updates the records without a current tenant" do
+      expect {
+        Project.joins(:manager).update_all(name: "New Name")
+      }.to change { project.reload.name }.from("Project 1").to("New Name")
+    end
+
     it "update the record" do
       expect {
         MultiTenant.with(account) do
           project.update(name: "New Name")
         end
+      }.to change { project.reload.name }.from("Project 1").to("New Name")
+    end
+
+    it "update the record without a current tenant" do
+      expect {
+        project.update(name: "New Name")
       }.to change { project.reload.name }.from("Project 1").to("New Name")
     end
   end
@@ -40,6 +52,12 @@ describe "Query Rewriter" do
       }.to change { Project.count }.from(3).to(1)
     end
 
+    it "delete_all the records without a current tenant" do
+      expect {
+        Project.joins(:manager).delete_all
+      }.to change { Project.count }.from(3).to(1)
+    end
+
     it "delete the record" do
       expect {
         MultiTenant.with(account) do
@@ -49,12 +67,26 @@ describe "Query Rewriter" do
       }.to change { Project.count }.from(3).to(1)
     end
 
+    it "delete the record without a current tenant" do
+      expect {
+        project1.delete
+        Project.delete(project2.id)
+      }.to change { Project.count }.from(3).to(1)
+    end
+
     it "destroy the record" do
       expect {
         MultiTenant.with(account) do
           project1.destroy
           Project.destroy(project2.id)
         end
+      }.to change { Project.count }.from(3).to(1)
+    end
+
+    it "destroy the record without a current tenant" do
+      expect {
+        project1.destroy
+        Project.destroy(project2.id)
       }.to change { Project.count }.from(3).to(1)
     end
   end


### PR DESCRIPTION
This affects `update_all`, `delete_all`, and `delete` on ActiveRecord >= 5.2, and `update_all` and `delete_all` involving `joins` for all ActiveRecord versions.

If you try to call one of those methods when current tenant is not set, it will add a `... AND tenant_id IS NULL` clause, which results in the query not executing as expected. Note that we already have this current tenant presence check [here](https://github.com/citusdata/activerecord-multi-tenant/blob/master/lib/activerecord-multi-tenant/query_rewriter.rb#L282) in the `build_arel` method, so we simply need to add it to these other methods.