### PR TITLE
order primary key with partition column first

### DIFF
--- a/lib/activerecord-multi-tenant/migrations.rb
+++ b/lib/activerecord-multi-tenant/migrations.rb
@@ -47,7 +47,7 @@ module ActiveRecord
         ret = orig_create_table(table_name, options.except(:partition_key), &block)
         if options[:partition_key] && options[:partition_key].to_s != 'id'
           execute "ALTER TABLE #{table_name} DROP CONSTRAINT #{table_name}_pkey"
-          execute "ALTER TABLE #{table_name} ADD PRIMARY KEY(id, \"#{options[:partition_key]}\")"
+          execute "ALTER TABLE #{table_name} ADD PRIMARY KEY(\"#{options[:partition_key]}\", id)"
         end
         ret
       end


### PR DESCRIPTION
Switches default primary key from `(id, tenant_id)` to `(tenant_id, id)` [as](http://docs.citusdata.com/en/v8.3/sharding/data_modeling.html#a-practical-example-of-co-location) [described](https://docs.citusdata.com/en/v6.0/migration/transitioning.html#schema-migration) [online](https://docs.citusdata.com/en/v6.0/sharding/data_modeling.html) and for increased [usability](https://use-the-index-luke.com/sql/where-clause/the-equals-operator/concatenated-keys).