### PR TITLE
Fix tenant missing error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ services:
 
 before_install:
   - docker-compose up -d
+  - gem install bundler -v 1.17.3
 
 script:
   - bundle exec rake spec

--- a/lib/activerecord-multi-tenant/sidekiq.rb
+++ b/lib/activerecord-multi-tenant/sidekiq.rb
@@ -18,7 +18,8 @@ module Sidekiq::Middleware::MultiTenant
   class Server
     def call(worker_class, msg, queue)
       if msg.has_key?('multi_tenant')
-        MultiTenant.with(msg['multi_tenant']['id']) do
+        tenant = msg['multi_tenant']['class'].constantize.find(msg['multi_tenant']['id'])
+        MultiTenant.with(tenant) do
           yield
         end
       else

--- a/spec/activerecord-multi-tenant/sidekiq_spec.rb
+++ b/spec/activerecord-multi-tenant/sidekiq_spec.rb
@@ -4,14 +4,14 @@ require 'activerecord-multi-tenant/sidekiq'
 
 describe MultiTenant, 'Sidekiq' do
   let(:server) { Sidekiq::Middleware::MultiTenant::Server.new }
+  let(:account) { Account.create(name: 'test') }
 
   describe 'server middleware' do
     it 'sets the multitenant context when provided in message' do
-      tenant_id = 1234
-      server.call(double, {'bogus' => 'message',
-        'multi_tenant' => { 'class' => MultiTenant.current_tenant_class, 'id' => tenant_id}},
+      server.call(double,{'bogus' => 'message',
+        'multi_tenant' => { 'class' => account.class.name, 'id' => account.id}},
         'bogus_queue') do
-        expect(MultiTenant.current_tenant).to eq(tenant_id)
+        expect(MultiTenant.current_tenant).to eq(account)
       end
     end
 


### PR DESCRIPTION
Commit 853ea7a8 lead to runtime error if `MultiTenant.default_tenant_class` is not set: 

    Only have tenant id, and no default tenant class set

This PR returns the program to its previous behavior.