### PR TITLE
Fixes #73: Deprecation warning in Rails 6.0?

### DIFF
--- a/lib/activerecord-multi-tenant/controller_extensions.rb
+++ b/lib/activerecord-multi-tenant/controller_extensions.rb
@@ -20,10 +20,6 @@ module MultiTenant
   end
 end
 
-if defined?(ActionController::Base)
-  ActionController::Base.extend MultiTenant::ControllerExtensions
-end
-
-if defined?(ActionController::API)
-  ActionController::API.extend MultiTenant::ControllerExtensions
+ActiveSupport.on_load(:action_controller) do |base|
+  base.extend MultiTenant::ControllerExtensions
 end

--- a/lib/activerecord-multi-tenant/copy_from_client.rb
+++ b/lib/activerecord-multi-tenant/copy_from_client.rb
@@ -28,6 +28,6 @@ module MultiTenant
   end
 end
 
-if defined?(ActiveRecord::Base)
-  ActiveRecord::Base.extend(MultiTenant::CopyFromClient)
+ActiveSupport.on_load(:active_record) do |base|
+  base.extend(MultiTenant::CopyFromClient)
 end

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -126,10 +126,9 @@ module MultiTenant
   end
 end
 
-if defined?(ActiveRecord::Base)
-  ActiveRecord::Base.extend(MultiTenant::ModelExtensionsClassMethods)
+ActiveSupport.on_load(:active_record) do |base|
+  base.extend MultiTenant::ModelExtensionsClassMethods
 end
-
 
 class ActiveRecord::Associations::Association
   alias skip_statement_cache_orig skip_statement_cache?


### PR DESCRIPTION
This PR backports the changes added here https://github.com/ErwinM/acts_as_tenant/commit/fea563c811d2798b5997a6fa174f6581fb389f06

The deprecation warnings don't appear when using `ActiveSupport.on_load` to lazy load classes