### PR TITLE
Allow update query without model

### DIFF
--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -34,6 +34,7 @@ module MultiTenant
   end
 
   def self.multi_tenant_model_for_arel(arel)
+    return nil unless arel.respond_to?(:ast)
     if arel.ast.relation.is_a? Arel::Nodes::JoinSource
       MultiTenant.multi_tenant_model_for_table(arel.ast.relation.left.table_name)
     else

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -90,4 +90,12 @@ describe "Query Rewriter" do
       }.to change { Project.count }.from(3).to(1)
     end
   end
+
+  context "when update without arel" do
+    it "can call method" do
+      expect {
+        ActiveRecord::Base.connection.update("SELECT 1")
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This PR allows ActiveRecord to call update without model.

Sometimes AR call update without arel ast. Actually I encountered this situation in MySQL.
ref. https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb#L164-L173

Main target database of activerecord-multi-tenant gem is postgresql. But I think this problem may happen too in postgresql.
