### PR TITLE
Init @discovering instance var in Context

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -31,6 +31,7 @@ module MultiTenant
       @arel_node = arel_node
       @known_relations = []
       @handled_relations = []
+      @discovering = false
     end
 
     def discover_relations


### PR DESCRIPTION
Initialize `@discovering` instance variable to false in `Context` to avoid warnings like

`/path/to/gems/activerecord-multi-tenant-1.1.0/lib/activerecord-multi-tenant/query_rewriter.rb:37: warning: instance variable @discovering not initialized`