### PR TITLE
fix has_many relation through multi-tenant model

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -129,6 +129,12 @@ class ActiveRecord::Associations::Association
   alias skip_statement_cache_orig skip_statement_cache?
   def skip_statement_cache?(*scope)
     return true if klass.respond_to?(:scoped_by_tenant?) && klass.scoped_by_tenant?
+
+    if reflection.through_reflection
+      through_klass = reflection.through_reflection.klass
+      return true if through_klass.respond_to?(:scoped_by_tenant?) && through_klass.scoped_by_tenant?
+    end
+
     skip_statement_cache_orig(*scope)
   end
 end

--- a/spec/activerecord-multi-tenant/record_finding_spec.rb
+++ b/spec/activerecord-multi-tenant/record_finding_spec.rb
@@ -59,4 +59,40 @@ describe MultiTenant, 'Record finding' do
       expect(second_found).to eq(second_record)
     end
   end
+
+  context 'model with has_many relation through multi-tenant model' do
+    let(:tenant_1) { Account.create! name: 'Tenant 1' }
+    let(:project_1) { tenant_1.projects.create! }
+
+    let(:tenant_2) { Account.create! name: 'Tenant 2' }
+    let(:project_2) { tenant_2.projects.create! }
+
+    let(:category) { Category.create! name: 'Category' }
+
+    before do
+      ProjectCategory.create! account: tenant_1, name: '1', project: project_1, category: category
+      ProjectCategory.create! account: tenant_2, name: '2', project: project_2, category: category
+    end
+
+    it 'can get model without creating query cache' do
+      MultiTenant.with(tenant_1) do
+        found_category = Project.find(project_1.id).categories.to_a.first
+        expect(found_category).to eq(category)
+      end
+    end
+
+    it 'can get model for other tenant' do
+      MultiTenant.with(tenant_2) do
+        found_category = Project.find(project_2.id).categories.to_a.first
+        expect(found_category).to eq(category)
+      end
+    end
+
+    it 'can get model without current_tenant' do
+      MultiTenant.without do
+        found_category = Project.find(project_2.id).categories.to_a.first
+        expect(found_category).to eq(category)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When a model has has_many relation to a non multi-tenant model through a multi-tenant model, the relation create and store an incorrect statement cache.

For example, in the spec schema, Project model has has_many relation to Category model(not multi-tenant) through ProjectCategory model(multi-tenant), so the additional spec in this PR will fail.

This PR modifies skip_statement_cache? method to check the mapping model is scoped_by_tenant or not, and skip cache if the mapping model is scoped.