### PR TITLE
Allow to use uuid as primary key on partition table

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -6,7 +6,15 @@ module MultiTenant
       if to_s.underscore.to_sym == tenant_name
         unless MultiTenant.with_write_only_mode_enabled?
           # This is the tenant model itself. Workaround for https://github.com/citusdata/citus/issues/687
-          before_create -> { self.id ||= self.class.connection.select_value("SELECT nextval('" + [self.class.table_name, self.class.primary_key, 'seq'].join('_') + "'::regclass)") }
+          before_create lambda {
+            self.id ||= if self.class.columns_hash['id'].type == :uuid
+                          SecureRandom.uuid
+                        else
+                          self.class.connection.select_value(
+                                "SELECT nextval('#{[self.class.table_name, self.class.primary_key, 'seq'].join('_')}'::regclass)"
+                              )
+                        end
+          }
         end
       else
         class << self

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -204,6 +204,7 @@ class Comment < ActiveRecord::Base
 end
 
 class Organization < ActiveRecord::Base
+  multi_tenant :organization
   has_many :uuid_records
 end
 


### PR DESCRIPTION
If a primary key of a partition table is an uuid and correspondent model is configured as multi_tenant, an error occurs because the multi_tenant method tries to get the next id presuming that id column is an postgres serial.  

This PR resolve it by verifying id column type before suggesting it.