### PR TITLE
Fix incorrect SQL generated when joining two models, one with a default scope

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -274,7 +274,11 @@ module ActiveRecord
                 if node.wheres.empty?
                   node.wheres = [enforcement_clause]
                 else
-                  node.wheres[0] = enforcement_clause.and(node.wheres[0])
+                  if node.wheres[0].is_a?(Arel::Nodes::And)
+                    node.wheres[0].children << enforcement_clause
+                  else
+                    node.wheres[0] = enforcement_clause.and(node.wheres[0])
+                  end
                 end
               else
                 raise "UnknownContext"

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -98,4 +98,21 @@ describe "Query Rewriter" do
       }.not_to raise_error
     end
   end
+
+  context "when joining with a model with a default scope" do
+    let!(:account) { Account.create!(name: "Test Account") }
+
+    it "fetches only records within the default scope" do
+      alive = Domain.create(name: "alive", account: account)
+      deleted = Domain.create(name: "deleted", deleted: true, account: account)
+      page_in_alive_domain = Page.create(name: "alive", account: account, domain: alive)
+      page_in_deleted_domain = Page.create(name: "deleted", account: account, domain: deleted)
+
+      expect(
+        MultiTenant.with(account) do
+          Page.joins(:domain).pluck(:id)
+        end
+      ).to eq([page_in_alive_domain.id])
+    end
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -89,10 +89,21 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :category_id, :integer
   end
 
-
   create_table :allowed_places, force: true, id: false do |t|
-  t.string :account_id, :integer
-  t.string :name, :string
+    t.string :account_id, :integer
+    t.string :name, :string
+  end
+
+  create_table :domains, force: true, partition_key: :account_id do |t|
+    t.column :account_id, :integer
+    t.column :name, :string
+    t.column :deleted, :boolean, default: false
+  end
+
+  create_table :pages, force: true, partition_key: :account_id do |t|
+    t.column :account_id, :integer
+    t.column :name, :string
+    t.column :domain_id, :integer
   end
 
   create_distributed_table :accounts, :id
@@ -108,6 +119,8 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :uuid_records, :organization_id
   create_distributed_table :project_categories, :account_id
   create_distributed_table :allowed_places, :account_id
+  create_distributed_table :domains, :account_id
+  create_distributed_table :pages, :account_id
   create_reference_table :categories
 end
 
@@ -204,7 +217,17 @@ class ProjectCategory < ActiveRecord::Base
   belongs_to :account
 end
 
-
 class AllowedPlace < ActiveRecord::Base
   multi_tenant :account
+end
+
+class Domain < ActiveRecord::Base
+  multi_tenant :account
+  has_many :pages
+  default_scope { where(deleted: false) }
+end
+
+class Page < ActiveRecord::Base
+  multi_tenant :account
+  belongs_to :domain
 end


### PR DESCRIPTION
Related to https://github.com/citusdata/activerecord-multi-tenant/issues/111

With activerecord-multi-tenant 1.1.1 and Rails 6.1, given the following models:

```ruby
class Domain < ActiveRecord::Base
  multi_tenant :account
  has_many :pages
  default_scope { where(deleted: false) }
end

class Page < ActiveRecord::Base
  multi_tenant :account
  belongs_to :domain
end
```

the query `Page.joins(:domain).to_a` generates incorrect SQL:

```sql
SELECT "pages".* FROM "pages"
INNER JOIN "domains" ON  AND "domains"."account_id" = 1
AND "domains"."deleted" = FALSE
AND "domains"."id" = "pages"."domain_id"
WHERE "pages"."account_id" = 1
```

note the extra "AND" after the "ON".

Somehow the Arel AST ends up having an And node with 3 children, one of them which is empty, therefore generating incorrect SQL. I figured that by reusing the node and adding the tenant clause to its children, instead of creating a new And node, the problem goes away. I added 2 tables/models Domain and Page and a test.

Additionally I had to rewrite some tests, mostly from a form like

```ruby
expected_sql = if rails_version_is_xyz?
  "SELECT * FROM table WHERE condition_a AND condition_b"
else
  "SELECT * FROM table WHERE condition_b AND condition_a"
end

expect(generated_sql).to eq(expected_sql)
```

to

```ruby
option1 = "SELECT * FROM table WHERE condition_a AND condition_b"
option2 = "SELECT * FROM table WHERE condition_b AND condition_a"

expect(generated_sql).to eq(option1).or(eq(option2))
```

since the order of the conditions does not matter and it changes depending on which version of Rails we are using.
