### PR TITLE
Use Github Actions for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '2.5'
+          - '2.6'
+          - '2.7'
+        gemfile:
+          - rails_5.2
+          - rails_6.0
+          - rails_6.1
+          - active_record_5.2
+          - active_record_6.0
+          - active_record_6.1
+        prepared_statements: [true, false]
+    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }}
+    env:
+       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+       PREPARED_STATEMENTS: ${{ matrix.prepared_statements && '1' }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          docker-compose up -d
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: |
+          bundle exec rake spec

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--force-color


### PR DESCRIPTION
Also updates mimemagic to fix the build.

Due to the nature of Github Actions, the new build is not attached to this PR, but instead to the commit on my fork: https://github.com/mlarraz/activerecord-multi-tenant/runs/2825158253

<img width="730" alt="image" src="https://user-images.githubusercontent.com/2575714/121978636-9c69e800-cd56-11eb-8ced-47045c892757.png">
