### PR TITLE
sidekiq: Allow dequeue even if tenant not found

### DIFF
--- a/lib/activerecord-multi-tenant/sidekiq.rb
+++ b/lib/activerecord-multi-tenant/sidekiq.rb
@@ -18,7 +18,11 @@ module Sidekiq::Middleware::MultiTenant
   class Server
     def call(worker_class, msg, queue)
       if msg.has_key?('multi_tenant')
-        tenant = msg['multi_tenant']['class'].constantize.find(msg['multi_tenant']['id'])
+        tenant = begin
+                   msg['multi_tenant']['class'].constantize.find(msg['multi_tenant']['id'])
+                 rescue ActiveRecord::RecordNotFound
+                   msg['multi_tenant']['id']
+                 end
         MultiTenant.with(tenant) do
           yield
         end


### PR DESCRIPTION
See also https://github.com/citusdata/activerecord-multi-tenant/pull/78

#78 always required an instance of a multitenant context to run background jobs. However, in this case, asynchronous processing cannot be performed in the context of the tenant that has already been deleted.

For instance, it is not practical to delete data related to a tenant synchronously, so there is a use case where only the tenant is deleted synchronously and the rest of the data is deleted asynchronously. Imagine something like [destroy_async](https://www.bigbinary.com/blog/rails-6-1-allows-associations-to-support-destroy_async-option-with-dependent-key).

This change will pass the `id` to `MultiTenant.with` instead if the tenant is not found, because it has already been deleted. This is the same behavior as before it was changed in #78.