### PR TITLE
Update for Rails 5+ removal of type_cast_for_database

### DIFF
--- a/lib/activerecord-multi-tenant/copy_from_client.rb
+++ b/lib/activerecord-multi-tenant/copy_from_client.rb
@@ -18,7 +18,7 @@ module MultiTenant
   module CopyFromClient
     def copy_from_client(columns, &block)
       conn         = connection.raw_connection
-      column_types = columns.map { |c| self.type_for_attribute(c.to_s) }
+      column_types = columns.map { |c| type_for_attribute(c.to_s) }
       helper = MultiTenant::CopyFromClientHelper.new(conn, column_types)
       conn.copy_data %{COPY #{quoted_table_name}("#{columns.join('","')}") FROM STDIN}, PG::TextEncoder::CopyRow.new do
         block.call helper

--- a/lib/activerecord-multi-tenant/copy_from_client.rb
+++ b/lib/activerecord-multi-tenant/copy_from_client.rb
@@ -9,7 +9,7 @@ module MultiTenant
     end
 
     def <<(row)
-      row = row.map.with_index { |val, idx| @column_types[idx].type_cast_for_database(val) }
+      row = row.map.with_index { |val, idx| @column_types[idx].serialize(val) }
       @conn.put_copy_data(row)
       @count += 1
     end
@@ -18,7 +18,7 @@ module MultiTenant
   module CopyFromClient
     def copy_from_client(columns, &block)
       conn         = connection.raw_connection
-      column_types = columns.map { |c| columns_hash[c.to_s] }
+      column_types = columns.map { |c| self.type_for_attribute(c.to_s) }
       helper = MultiTenant::CopyFromClientHelper.new(conn, column_types)
       conn.copy_data %{COPY #{quoted_table_name}("#{columns.join('","')}") FROM STDIN}, PG::TextEncoder::CopyRow.new do
         block.call helper


### PR DESCRIPTION
Updates the CopyFromClient functionality to support the removal of `type_cast_for_database` from Rails 5.2+

Issue: https://github.com/citusdata/activerecord-multi-tenant/issues/122

Gets the column types and casts the data.