### PR TITLE
Fixed bug when changing table_name after calling multi_tenant.

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -38,11 +38,11 @@ module MultiTenant
 
           def inherited(subclass)
             super
-            MultiTenant.register_multi_tenant_model(subclass.table_name, subclass) if subclass.table_name
+            MultiTenant.register_multi_tenant_model(subclass.table_name, subclass)
           end
         end
 
-        MultiTenant.register_multi_tenant_model(table_name, self) if table_name
+        MultiTenant.register_multi_tenant_model(table_name, self)
 
         @partition_key = options[:partition_key] || MultiTenant.partition_key(tenant_name)
         partition_key = @partition_key

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -38,11 +38,11 @@ module MultiTenant
 
           def inherited(subclass)
             super
-            MultiTenant.register_multi_tenant_model(subclass.table_name, subclass)
+            MultiTenant.register_multi_tenant_model(subclass)
           end
         end
 
-        MultiTenant.register_multi_tenant_model(table_name, self)
+        MultiTenant.register_multi_tenant_model(self)
 
         @partition_key = options[:partition_key] || MultiTenant.partition_key(tenant_name)
         partition_key = @partition_key

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -28,8 +28,7 @@ module MultiTenant
   def self.with_lock_workaround_enabled?; @@enable_with_lock_workaround; end
 
   # Registry that maps table names to models (used by the query rewriter)
-  # @deprecated _table_name is no longer used
-  def self.register_multi_tenant_model(_table_name, model_klass)
+  def self.register_multi_tenant_model(model_klass)
     @@multi_tenant_models ||= []
     @@multi_tenant_models.push(model_klass)
 

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -28,13 +28,24 @@ module MultiTenant
   def self.with_lock_workaround_enabled?; @@enable_with_lock_workaround; end
 
   # Registry that maps table names to models (used by the query rewriter)
-  def self.register_multi_tenant_model(table_name, model_klass)
-    @@multi_tenant_models ||= {}
-    @@multi_tenant_models[table_name.to_s] = model_klass
+  # @deprecated _table_name is no longer used
+  def self.register_multi_tenant_model(_table_name, model_klass)
+    @@multi_tenant_models ||= []
+    @@multi_tenant_models.push(model_klass)
+
+    remove_class_variable(:@@multi_tenant_model_table_names) if defined?(@@multi_tenant_model_table_names)
   end
+
   def self.multi_tenant_model_for_table(table_name)
-    @@multi_tenant_models ||= {}
-    @@multi_tenant_models[table_name.to_s]
+    @@multi_tenant_models ||= []
+
+    if !defined?(@@multi_tenant_model_table_names)
+      @@multi_tenant_model_table_names = @@multi_tenant_models.map { |model|
+        [model.table_name, model] if model.table_name
+      }.compact.to_h
+    end
+
+    @@multi_tenant_model_table_names[table_name.to_s]
   end
 
   def self.multi_tenant_model_for_arel(arel)

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -106,6 +106,11 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :domain_id, :integer
   end
 
+  create_table :posts, force: true, partition_key: :account_id do |t|
+    t.column :account_id, :integer
+    t.column :name, :string
+  end
+
   create_distributed_table :accounts, :id
   create_distributed_table :projects, :account_id
   create_distributed_table :managers, :account_id
@@ -121,6 +126,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :allowed_places, :account_id
   create_distributed_table :domains, :account_id
   create_distributed_table :pages, :account_id
+  create_distributed_table :posts, :account_id
   create_reference_table :categories
 end
 


### PR DESCRIPTION
If you change table_name after declaring multitenant, the scope isn't works fine.
Fixed it by changing the timing of getting the table_name to when it is actually needed, not when `multi_tenant` is called.