### PR TITLE
Rails 5+: Support optional: true for belongs_to

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -55,7 +55,7 @@ module MultiTenant
 
         # Create an implicit belongs_to association only if tenant class exists
         if MultiTenant.tenant_klass_defined?(tenant_name)
-          belongs_to tenant_name, **options.slice(:class_name, :inverse_of).merge(foreign_key: options[:partition_key])
+          belongs_to tenant_name, **options.slice(:class_name, :inverse_of, :optional).merge(foreign_key: options[:partition_key])
         end
 
         # New instances should have the tenant set

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -185,6 +185,16 @@ describe MultiTenant do
       end
     end
 
+    it 'handles belongs_to with optional: true' do
+      MultiTenant.with(account) do
+        sub_task
+      end
+
+      record = sub_task.optional_sub_tasks.create!
+      expect(record.reload.sub_task).to eq(sub_task)
+      expect(record.account_id).to eq(nil)
+    end
+
     it 'handles has_many through' do
       MultiTenant.with(account) do
         expect(project.sub_tasks).to eq [sub_task]

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -34,6 +34,13 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :type, :string
   end
 
+  create_table :optional_sub_tasks, force: true do |t|
+    t.references :account, :integer
+    t.column :sub_task_id, :integer
+    t.column :name, :string
+    t.column :type, :string
+  end
+
   create_table :countries, force: true do |t|
     t.column :name, :string
   end
@@ -134,6 +141,7 @@ class Account < ActiveRecord::Base
   multi_tenant :account
   has_many :projects
   has_one :manager, inverse_of: :account
+  has_many :optional_sub_tasks
 end
 
 class Project < ActiveRecord::Base
@@ -165,6 +173,15 @@ class SubTask < ActiveRecord::Base
   multi_tenant :account
   belongs_to :task
   has_one :project, through: :task
+  has_many :optional_sub_tasks
+end
+
+with_belongs_to_required_by_default do
+  class OptionalSubTask < ActiveRecord::Base
+    multi_tenant :account, optional: true
+    belongs_to :account, optional: true
+    belongs_to :sub_task
+  end
 end
 
 class StiSubTask < SubTask

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,4 +46,11 @@ def uses_prepared_statements?
   ActiveRecord::Base.connection.prepared_statements
 end
 
+def with_belongs_to_required_by_default(&block)
+  default_value = ActiveRecord::Base.belongs_to_required_by_default
+  ActiveRecord::Base.belongs_to_required_by_default = true
+  yield
+ensure
+  ActiveRecord::Base.belongs_to_required_by_default = default_value
+end
 require 'schema'


### PR DESCRIPTION
Rails5+ onwards `belongs_to` are required. Setting an `optional: true`,
make record persistence optional and a validation error is not raised.

This also makes it easy to rollout the gem on existing models.

This change now supports `optional: true` when overriding the `belongs_to`
association.

Since the specs don't quite behave like a traditional rails app, and there
are multiple CI matrices, only turning on `belongs_to_required_by_default`
for the respective test, instead of turning it for all tests at the `ActiveRecord::Base`
layer. Doing so, also makes a few other specs fail (unintentional, since they are testing
for something else.

For instance, this: https://github.com/shayonj/activerecord-multi-tenant/blob/b7bb41b162056195fbf6cb4d41e618bc87d5ac0f/spec/activerecord-multi-tenant/model_extensions_spec.rb\#L586-L588
would not be true, because the child association is required with `belongs_to_required_by_default`
being `true`.

Example usage

```ruby
    multi_tenant :account, optional: true
    belongs_to :account, optional: true
```

Fixes: https://github.com/citusdata/activerecord-multi-tenant/issues/146
