### PR TITLE
Error when calling a method that takes keyword arguments with MultiTenant.wrap_methods

### DIFF
--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -115,11 +115,11 @@ module MultiTenant
       original_method_name = :"_mt_original_#{method_name}"
       klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
         alias_method :#{original_method_name}, :#{method_name}
-        def #{method_name}(*args, &block)
+        def #{method_name}(...)
           if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil?
-            MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(*args, &block) }
+            MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(...) }
           else
-            #{original_method_name}(*args, &block)
+            #{original_method_name}(...)
           end
         end
       CODE


### PR DESCRIPTION
Starting with Ruby 3.0, argument delegation using `(*args)` will no longer work with keyword arguments.

```ruby
def hoge(a:)
  "a is #{a}"
end

def foo(*args)
  hoge(*args)
end

pp foo(a: 1)
# Ruby 2.7 => "a is 1"
# Ruby 3.0 => error: wrong number of arguments (given 1, expected 0; required keyword: a) (ArgumentError)
```

This will cause an error if you wrap a method that takes keyword arguments with `MultiTenant.wrap_methods`.

```ruby
class User < ActiveRecord::Base
  # ...
end

user = User.create(name: "homu", age: 14)

# OK: keyword arguments can be passed
user.touch(time: Time.current)

MultiTenant.wrap_methods(User, "self", :touch)

# NG: keyword arguments cannot be passed to wrapped methods.
# error: write unknown attribute `{:time=>2022-10-27 21:08:52.020778708 +0900}` (ActiveModel::MissingAttributeError)
user.touch(time: Time.current)
```

To solve this problem, you can use the forwarding arguments `(...) `, which was added in Ruby 2.7.

```ruby
def hoge(a:)
  "a is #{a}"
end

def foo(...)
  hoge(...)
end

pp foo(a: 1)
# Ruby 2.7 => "a is 1"
# Ruby 3.0 => "a is 1"
```

NOTE: Forwarding arguments do not work in Ruby 2.6.
