### PR TITLE
Allow Partitioned tables to be created without a primary key

### DIFF
--- a/lib/activerecord-multi-tenant/migrations.rb
+++ b/lib/activerecord-multi-tenant/migrations.rb
@@ -71,7 +71,7 @@ module ActiveRecord
       alias orig_create_table create_table
       def create_table(table_name, options = {}, &block)
         ret = orig_create_table(table_name, **options.except(:partition_key), &block)
-        if options[:partition_key] && options[:partition_key].to_s != 'id'
+        if options[:id] != false && options[:partition_key] && options[:partition_key].to_s != 'id'
           execute "ALTER TABLE #{table_name} DROP CONSTRAINT #{table_name}_pkey"
           execute "ALTER TABLE #{table_name} ADD PRIMARY KEY(\"#{options[:partition_key]}\", id)"
         end


### PR DESCRIPTION
There are some scenarios where partitioned tables are created without ids(for example, accessory tables

This patch allows tables to be created without a primary key(using rails migration id: false)