### PR TITLE
Handle updating a record tenant from nil to a reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Handle changing tenant from `nil` to a value [#173](https://github.com/citusdata/activerecord-multi-tenant/pull/173)
+
 ## 2.1.6      2022-11-23
 * Fix undefined wrap_methods error & wrap_methods version check [#170](https://github.com/citusdata/activerecord-multi-tenant/pull/170)
 

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -102,7 +102,8 @@ module MultiTenant
         include to_include
 
         around_save -> (record, block) {
-          if persisted? && MultiTenant.current_tenant_id.nil?
+          record_tenant = record.attribute_was(partition_key)
+          if persisted? && MultiTenant.current_tenant_id.nil? && !record_tenant.nil?
             MultiTenant.with(record.public_send(partition_key)) { block.call }
           else
             block.call
@@ -110,7 +111,8 @@ module MultiTenant
         }
 
         around_update -> (record, block) {
-          if MultiTenant.current_tenant_id.nil?
+          record_tenant = record.attribute_was(partition_key)
+          if MultiTenant.current_tenant_id.nil? && !record_tenant.nil?
             MultiTenant.with(record.public_send(partition_key)) { block.call }
           else
             block.call

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -209,6 +209,16 @@ describe MultiTenant do
       expect(record.account_id).to eq(nil)
     end
 
+    it 'handles changing tenant from nil to a value' do
+      record = OptionalSubTask.create(sub_task_id: sub_task.id)
+      expect(record.reload.sub_task).to eq(sub_task)
+      expect(record.account_id).to eq(nil)
+
+      record.account = account
+      record.save!
+      expect(record.reload.account_id).to eq(account.id)
+    end
+
     it 'handles has_many through' do
       MultiTenant.with(account) do
         expect(project.sub_tasks).to eq [sub_task]


### PR DESCRIPTION
Fixes https://github.com/citusdata/activerecord-multi-tenant/issues/104

I liked the proposed solution of getting the previous tenant value and only using the tenant id in the where clause if the ID was not nil previously.

I'm not sure on the formal process for submitting PRs to this repo since there's not contribution guidelines, so I added the Changelog entry directly