### PR TITLE
Only attempt to reload with MultiTenant when parition_key is present

### DIFF
--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -117,7 +117,7 @@ module MultiTenant
         klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
           alias_method :#{original_method_name}, :#{method_name}
           def #{method_name}(*args, &block)
-            if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil?
+            if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil? && #{owner}.class.respond_to?(:partition_key) && #{owner}.attributes.include?(#{owner}.class.partition_key)
               MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(*args, &block) }
             else
               #{original_method_name}(*args, &block)
@@ -133,7 +133,7 @@ module MultiTenant
         klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
         alias_method :#{original_method_name}, :#{method_name}
         def #{method_name}(...)
-          if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil?
+          if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil? && #{owner}.class.respond_to?(:partition_key) && #{owner}.attributes.include?(#{owner}.class.partition_key)
             MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(...) }
           else
             #{original_method_name}(...)


### PR DESCRIPTION
Proposal fix for: https://github.com/citusdata/activerecord-multi-tenant/issues/174

When using gems like graphql or similar, they can returns records from association which do not contain the `partition_key` column. In such cases, we'd see `ActiveModel::MissingAttributeError: missing attribute` error raised.

This change makes it so that we just call the upstream/original method (`original_method_name`) when there is no `partition_key` present in the record. Thus, resulting in no exception.

Also, adding a proof guard to ensure `partition_key` function is present on the class (`owner.class`). That is also another possibility of errors, especially when mocking models or overriding models in specs. Due to the way the ActiveRecord is overriden, we can also run into errors like "NoMethodError" for `partition_key`

So, overall, this means: When there is no `MultiTenant.current_tenant_id` present and the `owner`/record does
not have the `partition_key` column returned from the database (selective columns), we would reload
the record without  `MultiTenant`.

Def open to other ideas or ways for solving this, but think this would help to ensure there are no exceptions
during runtime. 