### PR TITLE
Adds codecov integration and removes eol ruby versions

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -49,3 +49,6 @@ jobs:
           bundler-cache: true
       - run: |
           bundle exec rake spec
+          
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -13,10 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
-          - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         gemfile:
           - rails_6.0
           - rails_6.1
@@ -28,13 +27,8 @@ jobs:
           - '10'
           - '11'
         prepared_statements: [true, false]
-        exclude:
-          # activesupport-7.0.0 requires ruby version >= 2.7.0
-          - ruby: '2.6'
-            gemfile: 'rails_7.0'
-          - ruby: '2.6'
-            gemfile: 'active_record_7.0'
-    name: Ruby ${{ matrix.ruby }} / ${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ prepared statements') || '' }} / Citus ${{ matrix.citus_version }}
+        
+    name: Rb:${{ matrix.ruby }}/${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ps') || '' }}/Cts ${{ matrix.citus_version }}
     env:
        BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
        PREPARED_STATEMENTS: ${{ matrix.prepared_statements && '1' }}
@@ -49,6 +43,6 @@ jobs:
           bundler-cache: true
       - run: |
           bundle exec rake spec
-          
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'codecov', require: false, group: 'test'
 gem 'appraisal'

--- a/activerecord-multi-tenant.gemspec
+++ b/activerecord-multi-tenant.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'thor'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
+  s.add_development_dependency 'codecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,12 @@ require 'activerecord-multi-tenant'
 require 'bundler'
 Bundler.require(:default, :development)
 
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 dbconfig = YAML::load(IO.read(File.join(File.dirname(__FILE__), 'database.yml')))
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))
 ActiveRecord::Base.establish_connection(dbconfig['test'])


### PR DESCRIPTION
https://endoflife.date/ruby

Ruby 2.6 is EOL and 2.7 is EOL in 3 days. I removed them and added 3.2 and added coverage support

https://app.codecov.io/gh/citusdata/activerecord-multi-tenant/tree/code_coverage/lib/activerecord-multi-tenant