### PR TITLE
Removes prepared statement cases from tests

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -26,12 +26,10 @@ jobs:
         citus_version:
           - '10'
           - '11'
-        prepared_statements: [true, false]
         
-    name: Rb:${{ matrix.ruby }}/${{ matrix.gemfile }} ${{ (matrix.prepared_statements && 'w/ps') || '' }}/Cts ${{ matrix.citus_version }}
+    name: Rb:${{ matrix.ruby }}/${{ matrix.gemfile }} / Cts ${{ matrix.citus_version }}
     env:
        BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
-       PREPARED_STATEMENTS: ${{ matrix.prepared_statements && '1' }}
        CITUS_VERSION: ${{ matrix.citus_version }}
     steps:
       - uses: actions/checkout@v3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,10 +48,6 @@ end
 MultiTenantTest::Application.config.secret_token = 'x' * 40
 MultiTenantTest::Application.config.secret_key_base = 'y' * 40
 
-def uses_prepared_statements?
-  ActiveRecord::Base.connection.prepared_statements
-end
-
 def with_belongs_to_required_by_default(&block)
   default_value = ActiveRecord::Base.belongs_to_required_by_default
   ActiveRecord::Base.belongs_to_required_by_default = true


### PR DESCRIPTION
Since Active Record 5.1 ActiveRecord::Base.connection.
prepared_statements is true and testing for false
is irrelavant, since it makes the application prone to SQL injection