### PR TITLE
Modified file name so bundler can automatically require gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,6 @@ Metrics/CyclomaticComplexity:
 Metrics/BlockNesting:
   Enabled: false
 
+Naming/FileName:
+  Exclude:
+    - 'lib/activerecord-multi-tenant.rb'

--- a/lib/activerecord-multi-tenant.rb
+++ b/lib/activerecord-multi-tenant.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'activerecord_multi_tenant'


### PR DESCRIPTION
The automatic loading no longer works because the file name has been changed by #184.

[Bundler automatically call require(gem name) on setup. ](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/runtime.rb#L55-L60 )
Therefore, a file matching the gem name must be placed in `$LOAD_PATH`.