### PR TITLE
Revert "Introduces ApplicationRecord" citusdata/activerecord-multi-tenant#188

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ It is required that you add `multi_tenant` definitions to your model in order to
 In the example of an analytics application, sharding on `customer_id`, annotate your models like this:
 
 ```ruby
-class PageView < ApplicationRecord
+class PageView < ActiveRecord::Base
   multi_tenant :customer
   belongs_to :site
 
   # ...
 end
 
-class Site < ApplicationRecord
+class Site < ActiveRecord::Base
   multi_tenant :customer
   has_many :page_views
 

--- a/lib/activerecord-multi-tenant/application_record.rb
+++ b/lib/activerecord-multi-tenant/application_record.rb
@@ -1,3 +1,0 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end

--- a/lib/activerecord-multi-tenant/copy_from_client.rb
+++ b/lib/activerecord-multi-tenant/copy_from_client.rb
@@ -31,7 +31,7 @@ module MultiTenant
   end
 end
 
-# Add copy_from_client to ApplicationRecord
+# Add copy_from_client to ActiveRecord::Base
 ActiveSupport.on_load(:active_record) do |base|
   base.extend(MultiTenant::CopyFromClient)
 end

--- a/lib/activerecord-multi-tenant/fast_truncate.rb
+++ b/lib/activerecord-multi-tenant/fast_truncate.rb
@@ -5,7 +5,7 @@ module MultiTenant
   module FastTruncate
     def self.run(exclude: ['schema_migrations'])
       # This is a slightly faster version of DatabaseCleaner.clean_with(:truncation, pre_count: true)
-      ApplicationRecord.connection.execute format(%(
+      ActiveRecord::Base.connection.execute format(%(
       DO LANGUAGE plpgsql $$
       DECLARE
         t record;

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -166,7 +166,7 @@ ActiveSupport.on_load(:active_record) do |base|
 
   # Ensure we have current_tenant_id in where clause when a cached ActiveRecord instance is being reloaded,
   # or update_columns without callbacks is called
-  MultiTenant.wrap_methods(ApplicationRecord, 'self', :delete, :reload, :update_columns)
+  MultiTenant.wrap_methods(ActiveRecord::Base, 'self', :delete, :reload, :update_columns)
 
   # Any queuries fired for fetching a singular association have the correct current_tenant_id in WHERE clause
   # reload is called anytime any record's association is accessed

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -380,4 +380,4 @@ module MultiTenantFindBy
   end
 end
 
-ApplicationRecord.singleton_class.prepend(MultiTenantFindBy)
+ActiveRecord::Base.singleton_class.prepend(MultiTenantFindBy)

--- a/lib/activerecord_multi_tenant.rb
+++ b/lib/activerecord_multi_tenant.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'activerecord-multi-tenant/application_record'
 require_relative 'activerecord-multi-tenant/controller_extensions' if Object.const_defined?(:ActionController)
 require_relative 'activerecord-multi-tenant/copy_from_client'
 require_relative 'activerecord-multi-tenant/fast_truncate'

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -74,7 +74,7 @@ describe MultiTenant do
 
   describe 'Tenant model with a nonstandard class name' do
     let(:account_klass) do
-      Class.new(ApplicationRecord) do
+      Class.new(ActiveRecord::Base) do
         self.table_name = 'account'
 
         def self.name
@@ -114,7 +114,7 @@ describe MultiTenant do
     end
 
     let(:post_klass) do
-      Class.new(ApplicationRecord) do
+      Class.new(ActiveRecord::Base) do
         self.table_name = 'unknown'
 
         multi_tenant(:account)

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -95,7 +95,7 @@ describe 'Query Rewriter' do
   context 'when update without arel' do
     it 'can call method' do
       expect do
-        ApplicationRecord.connection.update('SELECT 1')
+        ActiveRecord::Base.connection.update('SELECT 1')
       end.not_to raise_error
     end
   end

--- a/spec/activerecord-multi-tenant/record_callback_spec.rb
+++ b/spec/activerecord-multi-tenant/record_callback_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-class ProjectWithCallbacks < ApplicationRecord
+class ProjectWithCallbacks < ActiveRecord::Base
   self.table_name = :projects
 
   multi_tenant :account

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -139,14 +139,14 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_reference_table :categories
 end
 
-class Account < ApplicationRecord
+class Account < ActiveRecord::Base
   multi_tenant :account
   has_many :projects
   has_one :manager, inverse_of: :account
   has_many :optional_sub_tasks
 end
 
-class Project < ApplicationRecord
+class Project < ActiveRecord::Base
   multi_tenant :account
   has_one :manager
   has_many :tasks
@@ -158,12 +158,12 @@ class Project < ApplicationRecord
   validates_uniqueness_of :name, scope: [:account]
 end
 
-class Manager < ApplicationRecord
+class Manager < ActiveRecord::Base
   multi_tenant :account
   belongs_to :project
 end
 
-class Task < ApplicationRecord
+class Task < ActiveRecord::Base
   multi_tenant :account
   belongs_to :project
   has_many :sub_tasks
@@ -171,7 +171,7 @@ class Task < ApplicationRecord
   validates_uniqueness_of :name
 end
 
-class SubTask < ApplicationRecord
+class SubTask < ActiveRecord::Base
   multi_tenant :account
   belongs_to :task
   has_one :project, through: :task
@@ -179,7 +179,7 @@ class SubTask < ApplicationRecord
 end
 
 with_belongs_to_required_by_default do
-  class OptionalSubTask < ApplicationRecord
+  class OptionalSubTask < ActiveRecord::Base
     multi_tenant :account, optional: true
     belongs_to :sub_task
   end
@@ -188,26 +188,26 @@ end
 class StiSubTask < SubTask
 end
 
-class UnscopedModel < ApplicationRecord
+class UnscopedModel < ActiveRecord::Base
   validates_uniqueness_of :name
 end
 
-class AliasedTask < ApplicationRecord
+class AliasedTask < ActiveRecord::Base
   multi_tenant :account
   belongs_to :project_alias, class_name: 'Project'
 end
 
-class CustomPartitionKeyTask < ApplicationRecord
+class CustomPartitionKeyTask < ActiveRecord::Base
   multi_tenant :account, partition_key: 'accountID'
 
   validates_uniqueness_of :name, scope: [:account]
 end
 
-class PartitionKeyNotModelTask < ApplicationRecord
+class PartitionKeyNotModelTask < ActiveRecord::Base
   multi_tenant :non_model
 end
 
-class AbstractTask < ApplicationRecord
+class AbstractTask < ActiveRecord::Base
   self.abstract_class = true
   multi_tenant :non_model
 end
@@ -215,44 +215,44 @@ end
 class SubclassTask < AbstractTask
 end
 
-class Comment < ApplicationRecord
+class Comment < ActiveRecord::Base
   multi_tenant :account
   belongs_to :commentable, polymorphic: true
   belongs_to :task, -> { where(comments: { commentable_type: 'Task' }) }, foreign_key: 'commentable_id'
 end
 
-class Organization < ApplicationRecord
+class Organization < ActiveRecord::Base
   multi_tenant :organization
   has_many :uuid_records
 end
 
-class UuidRecord < ApplicationRecord
+class UuidRecord < ActiveRecord::Base
   multi_tenant :organization
 end
 
-class Category < ApplicationRecord
+class Category < ActiveRecord::Base
   has_many :project_categories
   has_many :projects, through: :project_categories
 end
 
-class ProjectCategory < ApplicationRecord
+class ProjectCategory < ActiveRecord::Base
   multi_tenant :account
   belongs_to :project
   belongs_to :category
   belongs_to :account
 end
 
-class AllowedPlace < ApplicationRecord
+class AllowedPlace < ActiveRecord::Base
   multi_tenant :account
 end
 
-class Domain < ApplicationRecord
+class Domain < ActiveRecord::Base
   multi_tenant :account
   has_many :pages
   default_scope { where(deleted: false) }
 end
 
-class Page < ApplicationRecord
+class Page < ActiveRecord::Base
   multi_tenant :account
   belongs_to :domain
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,8 @@ if ENV['CI'] == 'true'
 end
 
 dbconfig = YAML.safe_load(IO.read(File.join(File.dirname(__FILE__), 'database.yml')))
-ApplicationRecord.logger = Logger.new(File.join(File.dirname(__FILE__), 'debug.log'))
-ApplicationRecord.establish_connection(dbconfig['test'])
+ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), 'debug.log'))
+ActiveRecord::Base.establish_connection(dbconfig['test'])
 
 RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = true
@@ -54,11 +54,11 @@ MultiTenantTest::Application.config.secret_key_base = 'y' * 40
 # rubocop:disable Lint/UnusedMethodArgument
 # changing the name of the parameter breaks tests
 def with_belongs_to_required_by_default(&block)
-  default_value = ApplicationRecord.belongs_to_required_by_default
-  ApplicationRecord.belongs_to_required_by_default = true
+  default_value = ActiveRecord::Base.belongs_to_required_by_default
+  ActiveRecord::Base.belongs_to_required_by_default = true
   yield
 ensure
-  ApplicationRecord.belongs_to_required_by_default = default_value
+  ActiveRecord::Base.belongs_to_required_by_default = default_value
 end
 # rubocop:enable Lint/UnusedMethodArgument
 require 'schema'


### PR DESCRIPTION
Extending `ApplicationRecord` is bad.

- Whether or not to use ApplicationRecord is at the user's discretion. It should also not break existing application behavior.
- #188 does not care Rails application that mounted multiple engines.
  - isolated Rails Engine have isolated ApplicationRecord.
  - Example: `LoginService::ApplicationRecord` `ApiService::ApplicationRecord`.