### PR TITLE
Wrap ActiveRecord::Base with ActiveSupport.on_load

### DIFF
--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -370,7 +370,6 @@ module ActiveRecord
   end
 end
 
-require 'active_record/base'
 module MultiTenantFindBy
   def cached_find_by_statement(key, &block)
     return super unless respond_to?(:scoped_by_tenant?) && scoped_by_tenant?
@@ -380,4 +379,6 @@ module MultiTenantFindBy
   end
 end
 
-ActiveRecord::Base.singleton_class.prepend(MultiTenantFindBy)
+ActiveSupport.on_load(:active_record) do |base|
+  base.singleton_class.prepend(MultiTenantFindBy)
+end

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -131,6 +131,13 @@ describe MultiTenant do
     it { expect(@posts).to eq([@post1]) }
   end
 
+  describe 'inspect method filters senstive column values' do
+    it 'filters senstive value' do
+      account = Account.new(name: 'foo', password: 'baz')
+      expect(account.inspect).to eq '#<Account id: nil, name: nil, subdomain: nil, domain: nil, password: [FILTERED]>'
+    end
+  end
+
   # Scoping models
   describe 'Project.all should be scoped to the current tenant if set' do
     before do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -9,6 +9,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
     t.column :subdomain, :string
     t.column :domain, :string
+    t.column :password, :string
   end
 
   create_table :projects, force: true, partition_key: :account_id do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,8 +38,6 @@ end
 
 require 'activerecord_multi_tenant'
 
-MultiTenantTest::Application.config.secret_token = 'x' * 40
-MultiTenantTest::Application.config.secret_key_base = 'y' * 40
 MultiTenantTest::Application.config.filter_parameters = [:password]
 
 require 'bundler'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,20 @@ require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'rspec/rails'
 
+module MultiTenantTest
+  class Application < Rails::Application; end
+end
+
+# NOTE: Specifies columns which shouldn't be exposed while calling #inspect.
+ActiveSupport.on_load(:active_record) do
+  self.filter_attributes += MultiTenantTest::Application.config.filter_parameters
+end
+
 require 'activerecord_multi_tenant'
+
+MultiTenantTest::Application.config.secret_token = 'x' * 40
+MultiTenantTest::Application.config.secret_key_base = 'y' * 40
+MultiTenantTest::Application.config.filter_parameters = [:password]
 
 require 'bundler'
 Bundler.require(:default, :development)
@@ -54,13 +67,6 @@ RSpec.configure do |config|
     MultiTenant::FastTruncate.run
   end
 end
-
-module MultiTenantTest
-  class Application < Rails::Application; end
-end
-
-MultiTenantTest::Application.config.secret_token = 'x' * 40
-MultiTenantTest::Application.config.secret_key_base = 'y' * 40
 
 # rubocop:disable Lint/UnusedMethodArgument
 # changing the name of the parameter breaks tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,13 +31,18 @@ module MultiTenantTest
   class Application < Rails::Application; end
 end
 
-# NOTE: Specifies columns which shouldn't be exposed while calling #inspect.
+# Specifies columns which shouldn't be exposed while calling #inspect.
 ActiveSupport.on_load(:active_record) do
   self.filter_attributes += MultiTenantTest::Application.config.filter_parameters
 end
 
 require 'activerecord_multi_tenant'
 
+# It's necessary for testing the filtering of senstive column values in ActiveRecord.
+# Refer to "describe 'inspect method filters senstive column values'"
+#
+# To verify that ActiveSupport.on_load(:active_record) is not being unnecessarily invoked,
+# this line should be placed after "require 'activerecord_multi_tenant'" and before ActiveRecord::Base is called.
 MultiTenantTest::Application.config.filter_parameters = [:password]
 
 require 'bundler'


### PR DESCRIPTION
This PR try to fix #198

Cause
---

### Before: Rails initialization order is NOT good.

First. Set `ActiveRecord::Base.filter_attributes` which is empty array.

```rb
# https://github.com/rails/rails/blob/v7.0.5/activerecord/lib/active_record/railtie.rb#L318-L322
initializer "active_record.set_filter_attributes" do
  ActiveSupport.on_load(:active_record) do
    self.filter_attributes += Rails.application.config.filter_parameters
  end
end
```

Second. Initialize `Rails.application.config.filter_parameters`

```rb
# My Rails Application
# config/initializers/filter_parameter_logging.rb
Rails.application.config.filter_parameters += [
  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
]
````
### After: Rails initialization order is good.

First. Initialize `Rails.application.config.filter_parameters`

```rb
# My Rails Application
# config/initializers/filter_parameter_logging.rb
Rails.application.config.filter_parameters += [
  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
]
````

Second. Set `ActiveRecord::Base.filter_attributes` which is NOT empty array.

```rb
# https://github.com/rails/rails/blob/v7.0.5/activerecord/lib/active_record/railtie.rb#L318-L322
initializer "active_record.set_filter_attributes" do
  ActiveSupport.on_load(:active_record) do
    self.filter_attributes += Rails.application.config.filter_parameters
  end
end
```

Test
---

Use fixed gem

```rb
# Gemfile
gem 'activerecord-multi-tenant', github: 'nipe0324/activerecord-multi-tenant', branch: 'wrap_active_support_on_load'
```

Run `bundle install`. And, `bin/rails c` and `filter_parameters` works!!

```rb
Loading development environment (Rails 7.0.5)
irb(main):001:0> Rails.application.config.filter_parameters
=> [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]
irb(main):002:0> Customer.inspection_filter
=> 
#<ActiveSupport::ParameterFilter:0x0000000111df2188
 @filters=[:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn],
 @mask="[FILTERED]">
irb(main):003:0> Customer.new(name: 'name', token: 'some-token')
=> #<Customer:0x0000000111e9b878 id: nil, name: "name", token: "[FILTERED]", created_at: nil, updated_at: nil>
```