### PR TITLE
namespace tenants to support multiple kinds of tenant models

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -40,6 +40,8 @@ module MultiTenant
                                         .try(:instance_variable_get, :@partition_key)
           end
 
+          attr_reader :partition_namespace
+
           # Avoid primary_key errors when using composite primary keys (e.g. id, tenant_id)
           def primary_key
             if defined?(PRIMARY_KEY_NOT_SET) ? !PRIMARY_KEY_NOT_SET.equal?(@primary_key) : @primary_key
@@ -65,6 +67,8 @@ module MultiTenant
 
         @partition_key = options[:partition_key] || MultiTenant.partition_key(tenant_name)
         partition_key = @partition_key
+
+        @partition_namespace = options[:namespace] || :default
 
         # Create an implicit belongs_to association only if tenant class exists
         if MultiTenant.tenant_klass_defined?(tenant_name, options)

--- a/spec/activerecord-multi-tenant/model_extensions_spec.rb
+++ b/spec/activerecord-multi-tenant/model_extensions_spec.rb
@@ -63,6 +63,16 @@ describe MultiTenant do
     it { expect(@custom_partition_key_task.account).to eq(@account) }
   end
 
+  describe 'Handles custom partition_namespace on tenant model' do
+    before do
+      @account = Account.create! name: 'foo'
+      MultiTenant.set_current_tenant(:custom_namespace, @account)
+      @custom_partition_namespace_task = CustomPartitionNamespaceTask.create! name: 'foo'
+    end
+
+    it { expect(@custom_partition_namespace_task.account).to eq(@account) }
+  end
+
   describe 'Tenant model not defined' do
     before do
       MultiTenant.current_tenant = 77

--- a/spec/activerecord-multi-tenant/multi_tenant_spec.rb
+++ b/spec/activerecord-multi-tenant/multi_tenant_spec.rb
@@ -3,6 +3,50 @@
 require 'spec_helper'
 
 RSpec.describe MultiTenant do
+  describe '.with' do
+    it 'sets the tenant in the default namespace' do
+      MultiTenant.with(1) do
+        expect(MultiTenant.current_tenant).to eq(1)
+      end
+    end
+
+    it 'sets the tenant in the namespace given' do
+      MultiTenant.with(namespace: 1) do
+        expect(MultiTenant.current_tenant).to be_nil
+        expect(MultiTenant.current_tenant(namespace: :namespace)).to eq(1)
+      end
+    end
+
+    it 'raises if there was an empty hash' do
+      expect do
+        MultiTenant.with({}) {}
+      end.to raise_error(StandardError, 'must set at least one namespace')
+    end
+
+    it 'raises if there are multiple namespaces' do
+      expect do
+        MultiTenant.with(first: 1, second: 2) {}
+      end.to raise_error(StandardError, 'can only set one namespace at a time')
+    end
+  end
+
+  describe '.without' do
+    it 'sets the tenant to nil in the default namespace' do
+      MultiTenant.without do
+        expect(MultiTenant.current_tenant).to be_nil
+      end
+    end
+
+    it 'sets the tenant to nil in the namespace given' do
+      MultiTenant.with(1) do
+        MultiTenant.without(namespace: :namespace) do
+          expect(MultiTenant.current_tenant(namespace: :namespace)).to be_nil
+          expect(MultiTenant.current_tenant).to eq(1)
+        end
+      end
+    end
+  end
+
   describe '.load_current_tenant!' do
     let(:fake_tenant) { OpenStruct.new(id: 1) }
     let(:mock_klass) { double(find: fake_tenant) }

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -74,6 +74,11 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
   end
 
+  create_table :custom_partition_namespace_tasks, force: true, partition_key: :account_id do |t|
+    t.column :account_id, :integer
+    t.column :name, :string
+  end
+
   create_table :comments, force: true, partition_key: :account_id do |t|
     t.column :account_id, :integer
     t.column :commentable_id, :integer
@@ -139,6 +144,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
   create_distributed_table :sub_tasks, :account_id
   create_distributed_table :aliased_tasks, :account_id
   create_distributed_table :custom_partition_key_tasks, :accountID
+  create_distributed_table :custom_partition_namespace_tasks, :account_id
   create_distributed_table :comments, :account_id
   create_distributed_table :partition_key_not_model_tasks, :non_model_id
   create_distributed_table :subclass_tasks, :non_model_id
@@ -217,6 +223,10 @@ class CustomPartitionKeyTask < ActiveRecord::Base
   multi_tenant :account, partition_key: 'accountID'
 
   validates_uniqueness_of :name, scope: [:account]
+end
+
+class CustomPartitionNamespaceTask < ActiveRecord::Base
+  multi_tenant :account, namespace: :custom_namespace
 end
 
 class PartitionKeyNotModelTask < ActiveRecord::Base

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,9 @@ ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), 'debug.
 ActiveRecord::Base.establish_connection(dbconfig['test'])
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
   config.infer_base_class_for_anonymous_controllers = true
   config.use_transactional_fixtures = false
   config.filter_run_excluding type: :controller unless Object.const_defined?(:ActionController)


### PR DESCRIPTION
We have 2 different databases in our architecture, roughly users and batches.

The users database has been sharded already with this gem, like this.

```ruby
class User
  multi_tenant :user
end

class Addresses
  multi_tenant :user
end
```

We are now trying to shard our batches databases with models like this.

```ruby
class Batch
  multi_tenant :batch
end

class BatchStates
  multi_tenant :batch
end
```

These models are both defined in the same monotlithic rails app.

We are finding it awkward to use `MultiTenant.with` on 2 different kinds of tenants.

```ruby
MultiTenant.with(user_id) do
  Addresses.count # fine

  MultiTenant.with(batch_id) do
    BatchStates.count # fine
    Addresses.count # :boom:
  end
end
```
