### PR TITLE
Use prepend instead of alias

### DIFF
--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -130,39 +130,21 @@ module MultiTenant
   # Wrap calls to any of `method_names` on an instance Class `klass` with MultiTenant.with
   # when `'owner'` (evaluated in context of the klass instance) is a ActiveRecord model instance that is multi-tenant
   # Instruments the methods provided with previously set Multitenant parameters
-  # In Ruby 2 using splat (*) operator with `&block` is not supported, so we need to use `method(...)` syntax
   # TODO: Could not understand the use of owner here. Need to check
-  if Gem::Version.create(RUBY_VERSION) < Gem::Version.new('3.0.0')
-    def self.wrap_methods(klass, owner, *method_names)
-      method_names.each do |method_name|
-        original_method_name = :"_mt_original_#{method_name}"
-        klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
-          alias_method :#{original_method_name}, :#{method_name}
-          def #{method_name}(*args, &block)
-            if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil? && #{owner}.class.respond_to?(:partition_key) && #{owner}.attributes.include?(#{owner}.class.partition_key)
-              MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(*args, &block) }
-            else
-              #{original_method_name}(*args, &block)
-            end
-          end
-        CODE
-      end
-    end
-  else
-    def self.wrap_methods(klass, owner, *method_names)
-      method_names.each do |method_name|
-        original_method_name = :"_mt_original_#{method_name}"
-        klass.class_eval <<-CODE, __FILE__, __LINE__ + 1
-        alias_method :#{original_method_name}, :#{method_name}
+  def self.wrap_methods(klass, owner, *method_names)
+    mod = Module.new
+    klass.prepend(mod)
+
+    method_names.each do |method_name|
+      mod.module_eval <<-CODE, __FILE__, __LINE__ + 1
         def #{method_name}(...)
           if MultiTenant.multi_tenant_model_for_table(#{owner}.class.table_name).present? && #{owner}.persisted? && MultiTenant.current_tenant_id.nil? && #{owner}.class.respond_to?(:partition_key) && #{owner}.attributes.include?(#{owner}.class.partition_key)
-            MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { #{original_method_name}(...) }
+            MultiTenant.with(#{owner}.public_send(#{owner}.class.partition_key)) { super }
           else
-            #{original_method_name}(...)
+            super
           end
         end
-        CODE
-      end
+      CODE
     end
   end
 

--- a/lib/activerecord-multi-tenant/query_rewriter.rb
+++ b/lib/activerecord-multi-tenant/query_rewriter.rb
@@ -284,13 +284,10 @@ ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend(MultiTenant::DatabaseS
 
 Arel::Visitors::ToSql.include(MultiTenant::TenantValueVisitor)
 
-require 'active_record/relation'
-module ActiveRecord
-  module QueryMethods
-    alias build_arel_orig build_arel
-
-    def build_arel(*args)
-      arel = build_arel_orig(*args)
+module MultiTenant
+  module QueryMethodsExtensions
+    def build_arel(*)
+      arel = super
 
       unless MultiTenant.with_write_only_mode_enabled?
         visitor = MultiTenant::ArelTenantVisitor.new(arel)
@@ -373,6 +370,9 @@ module ActiveRecord
     end
   end
 end
+
+require 'active_record/relation'
+ActiveRecord::QueryMethods.prepend(MultiTenant::QueryMethodsExtensions)
 
 module MultiTenantFindBy
   def cached_find_by_statement(key, &block)

--- a/spec/activerecord-multi-tenant/multi_tenant_spec.rb
+++ b/spec/activerecord-multi-tenant/multi_tenant_spec.rb
@@ -118,4 +118,32 @@ RSpec.describe MultiTenant do
       end
     end
   end
+
+  describe '.wrap_methods' do
+    context 'when method is already prepended' do
+      it 'is not an stack error' do
+        klass = Class.new do
+          def hello
+            'hello'
+          end
+        end
+
+        klass.prepend(Module.new do
+          def hello
+            "#{super} world"
+          end
+
+          def owner
+            Class.new(ActiveRecord::Base) do
+              self.table_name = 'accounts'
+            end.new
+          end
+        end)
+
+        MultiTenant.wrap_methods(klass, :owner, :hello)
+
+        expect(klass.new.hello).to eq('hello world')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The method extension method using alias may result in a stack overflow.
I actually found that using it with gem such as [ridgepole](https://github.com/ridgepole/ridgepole/blob/2.0/lib/ridgepole/schema_dumper_ext.rb#L7) caused a stack overflow, so I replaced `alias` with `prepend`.

## Example of stack overflow.

**original**

```ruby
class Hello
  def hello
    'hello'
  end
end
```

**1. alias style extension**

```ruby
Hello.class_eval do
  alias orig_hello hello

  def hello
    "#{orig_hello} world"
  end
end
```

**2. prepend style extension**

```ruby
Hello.prepend(Module.new do
  def hello
    super
  end
end)
```


The result of executing 1(alias), 2(prepend) and `Hello.new.hello` in that order is `'hello world'`.
The result of executing 2(prepend), 1(alias) and `Hello.new.hello` in that order is SystemStackError(stack level too deep).
