### PR TITLE
Fix issue to avoid errors when `table_name` is nil

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -52,7 +52,8 @@ module MultiTenant
 
             @primary_key = if primary_object_keys.size == 1
                              primary_object_keys.first
-                           elsif connection.schema_cache.columns_hash(table_name).include? DEFAULT_ID_FIELD
+                           elsif table_name &&
+                                 connection.schema_cache.columns_hash(table_name).include?(DEFAULT_ID_FIELD)
                              DEFAULT_ID_FIELD
                            end
           end


### PR DESCRIPTION
## Summary
This pull request addresses a series of `no implicit conversion of nil into String` errors that surfaced after upgrading Rails to version 7.1 in our application.

## Changes
- Implemented nil checks in the affected areas to prevent the aforementioned errors.

## Additional Information
- All specs within this gem are passing post-implementation.

## Discussion
I've opened this pull request to not only propose a fix but also to highlight the issue for further review. The addition of nil checks has resolved the immediate errors, but I am open to feedback if there are more robust solutions or additional checks that we should consider.

Please let me know if there are any other aspects of the code that require attention or if there are any best practices I might have overlooked in this initial approach.
