### PR TITLE
fix PG::SyntaxError when #undistribute_table is called

### DIFF
--- a/lib/activerecord-multi-tenant/migrations.rb
+++ b/lib/activerecord-multi-tenant/migrations.rb
@@ -31,7 +31,7 @@ module MultiTenant
     def undistribute_table(table_name)
       return unless citus_version.present?
 
-      execute "SELECT undistribute_table($$#{table_name}$$))"
+      execute "SELECT undistribute_table($$#{table_name}$$)"
     end
 
     def rebalance_table_shards


### PR DESCRIPTION
Issue is described here: #225.

This PR aims to fix the `PG::SyntaxError` present on: https://github.com/citusdata/activerecord-multi-tenant/blob/9939b5e8f76a6e59d29c3e35b083205864d7d479/lib/activerecord-multi-tenant/migrations.rb#L29