### PR TITLE
Do not dynamically load tenant model specified in autoload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Once you are ready to enforce tenancy, make your tenant_id column NOT NULL and s
 * **What if my tenant model is not defined in my application?**
 
   The tenant model does not have to be defined. Use the gem as if the model was present. `MultiTenant.with` accepts either a tenant id or model instance.
+  However, you should pass `skip_reflection: true` when calling `multi_tenant()` to avoid generating a relation.
 
 ## Credits
 

--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -70,7 +70,7 @@ module MultiTenant
         partition_key = @partition_key
 
         # Create an implicit belongs_to association only if tenant class exists
-        if MultiTenant.tenant_klass_defined?(tenant_name, options)
+        unless options[:skip_reflection]
           belongs_to tenant_name, **options.slice(:class_name, :inverse_of, :optional)
                                            .merge(foreign_key: options[:partition_key])
         end
@@ -106,7 +106,7 @@ module MultiTenant
             tenant_id
           end
 
-          if MultiTenant.tenant_klass_defined?(tenant_name, options)
+          unless options[:skip_reflection]
             define_method "#{tenant_name}=" do |model|
               super(model)
               if send("#{partition_key}_changed?") && persisted? && !send("#{partition_key}_was").nil?

--- a/lib/activerecord-multi-tenant/multi_tenant.rb
+++ b/lib/activerecord-multi-tenant/multi_tenant.rb
@@ -7,15 +7,6 @@ module MultiTenant
     attribute :tenant
   end
 
-  def self.tenant_klass_defined?(tenant_name, options = {})
-    class_name = if options[:class_name].present?
-                   options[:class_name]
-                 else
-                   tenant_name.to_s.classify
-                 end
-    !!class_name.safe_constantize
-  end
-
   def self.partition_key(tenant_name)
     "#{tenant_name.to_s.underscore}_id"
   end

--- a/spec/activerecord-multi-tenant/multi_tenant_spec.rb
+++ b/spec/activerecord-multi-tenant/multi_tenant_spec.rb
@@ -65,60 +65,6 @@ RSpec.describe MultiTenant do
     end
   end
 
-  describe '.tenant_klass_defined?' do
-    context 'without options' do
-      before(:all) do
-        class SampleTenant < ActiveRecord::Base
-          multi_tenant :sample_tenant
-        end
-      end
-
-      it 'return true with valid tenant_name' do
-        expect(MultiTenant.tenant_klass_defined?(:sample_tenant)).to eq(true)
-      end
-
-      it 'return false with invalid_tenant_name' do
-        invalid_tenant_name = :tenant
-        expect(MultiTenant.tenant_klass_defined?(invalid_tenant_name)).to eq(false)
-      end
-    end
-
-    context 'with options' do
-      context 'and valid class_name' do
-        it 'return true' do
-          class SampleTenant < ActiveRecord::Base
-            multi_tenant :tenant
-          end
-
-          tenant_name = :tenant
-          options = {
-            class_name: 'SampleTenant'
-          }
-          expect(MultiTenant.tenant_klass_defined?(tenant_name, options)).to eq(true)
-        end
-
-        it 'return true when tenant class is nested' do
-          module SampleModule
-            class SampleNestedTenant < ActiveRecord::Base
-              multi_tenant :tenant
-            end
-            # rubocop:disable Layout/TrailingWhitespace
-            # Trailing whitespace is intentionally left here
-            
-            class AnotherTenant < ActiveRecord::Base
-            end
-            # rubocop:enable Layout/TrailingWhitespace
-          end
-          tenant_name = :tenant
-          options = {
-            class_name: 'SampleModule::SampleNestedTenant'
-          }
-          expect(MultiTenant.tenant_klass_defined?(tenant_name, options)).to eq(true)
-        end
-      end
-    end
-  end
-
   describe '.wrap_methods' do
     context 'when method is already prepended' do
       it 'is not an stack error' do

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -220,12 +220,12 @@ class CustomPartitionKeyTask < ActiveRecord::Base
 end
 
 class PartitionKeyNotModelTask < ActiveRecord::Base
-  multi_tenant :non_model
+  multi_tenant :non_model, skip_reflection: true
 end
 
 class AbstractTask < ActiveRecord::Base
   self.abstract_class = true
-  multi_tenant :non_model
+  multi_tenant :non_model, skip_reflection: true
 end
 
 class SubclassTask < AbstractTask


### PR DESCRIPTION
The basic way of Rails is that application code in the development environment is lazy loaded.
For this reason, `class_name` is passed as a string rather than a class in the reflection definition, and the string is not constantized until it is evaluated.
This is done to reduce performance issues and the complex locking load of constant-loading logic.

Now activerecord-multitenant is loading the class specified in the argument to multi_tenant() without lazy loading.
This conditional statement was added at https://github.com/citusdata/activerecord-multi-tenant/pull/6, but I have been fixed.
Note that for projects where the tenant model does not exist, the existing behavior is supported by specifying `skip_reflection: true`.
