### PR TITLE
Fix TypeError: Cannot visit Arel::SelectManager when executing a subquery with Arel

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -165,6 +165,10 @@ module MultiTenant
       visit obj.havings
     end
 
+    def visit_Arel_SelectManager(obj)
+      visit obj.ast
+    end
+
     def visit_Arel_Nodes_SelectStatement(obj)
       visit obj.cores
       visit obj.orders

--- a/spec/activerecord-multi-tenant/record_finding_spec.rb
+++ b/spec/activerecord-multi-tenant/record_finding_spec.rb
@@ -62,6 +62,19 @@ describe MultiTenant, 'Record finding' do
     end
   end
 
+  it 'can search for tenant object using subquery with Arel' do
+    account = Account.create! name: 'test'
+    project = account.projects.create! name: 'test'
+
+    MultiTenant.with(account) do
+      project_table = Project.arel_table
+      subquery = project_table.project(project_table[:id])
+      query = Project.where(Arel::Nodes::InfixOperation.new('IN', project_table['id'], subquery))
+
+      expect(Project.where(id: query).to_a.first).to eq project
+    end
+  end
+
   context 'model with has_many relation through multi-tenant model' do
     let(:tenant1) { Account.create! name: 'Tenant 1' }
     let(:project1) { tenant1.projects.create! }


### PR DESCRIPTION
When executing a subquery using Arel, a `TypeError: Cannot visit Arel::SelectManager` is raised if Arel::SelectManager is called internally.

To fix this error, I have added a visit_Arel_SelectManager to arel_visitors_depth_first.rb and test. The implementation is based on https://github.com/rails/rails/blob/f6918a5b5d0b8c3a700513c2624cc195e0a78d14/activerecord/lib/arel/visitors/to_sql.rb#L358-L361