### PR TITLE
Delegate primary_key to super in abstract class

### DIFF
--- a/lib/activerecord-multi-tenant/model_extensions.rb
+++ b/lib/activerecord-multi-tenant/model_extensions.rb
@@ -44,6 +44,10 @@ module MultiTenant
 
           # Avoid primary_key errors when using composite primary keys (e.g. id, tenant_id)
           def primary_key
+            # If receiver is an abstract class, it doesn't have a table_name
+            # In this case, we don't care about the primary key, so delegate to super
+            return super unless table_name
+
             if defined?(PRIMARY_KEY_NOT_SET) ? !PRIMARY_KEY_NOT_SET.equal?(@primary_key) : @primary_key
               return @primary_key
             end
@@ -52,8 +56,7 @@ module MultiTenant
 
             @primary_key = if primary_object_keys.size == 1
                              primary_object_keys.first
-                           elsif table_name &&
-                                 connection.schema_cache.columns_hash(table_name).include?(DEFAULT_ID_FIELD)
+                           elsif connection.schema_cache.columns_hash(table_name).include?(DEFAULT_ID_FIELD)
                              DEFAULT_ID_FIELD
                            end
           end


### PR DESCRIPTION
**Related Issues and PRs:**
- https://github.com/citusdata/activerecord-multi-tenant/pull/218
- https://github.com/citusdata/activerecord-multi-tenant/issues/230

When I submitted PR #218, my approach was rather symptomatic. Now, I have a better understanding.

- Rails 7.1 has added support for `composite_primary_key` as mentioned in the [Ruby on Rails 7.1 Release Notes](https://guides.rubyonrails.org/7_1_release_notes.html#composite-primary-keys).
- This change ensures that `primary_key` is checked for all ActiveRecord classes, including abstract classes.
- The `.primary_key` method implemented in this gem throws an exception for abstract classes because `table_name` is nil. I added a nil guard to make `AbstractClass.primary_key` return nil (#218).

However, this approach seems inappropriate. As indicated by the following link, ActiveRecord is designed to have `AbstractClass.primary_key` return `'id'` and not nil:
https://github.com/rails/rails/blob/de4d8744744acab2dd9db0683ccf784ea45810b2/activerecord/lib/active_record/attribute_methods/primary_key.rb#L106-L116

The value of `AbstractClass.primary_key` is not the concern of this PR, so I have updated the implementation to delegate to `super` in such cases.

If there are any other approaches or suggestions, please let me know and I will implement them accordingly.