### PR TITLE
Update actions/checkout action to v4

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ruby-version: 3.2
           bundler-cache: true
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Rubocop static code analysis
         run: |
           gem install rubocop
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install python dependencies
       run: |
         pip install -r docs/requirements.txt
@@ -66,7 +66,7 @@ jobs:
        APPRAISAL: ${{ matrix.appraisal }}
        CITUS_VERSION: ${{ matrix.citus_version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Start Citus Database environment
         run: docker-compose up -d


### PR DESCRIPTION
Fixes the deprecation warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.