### PR TITLE
ci: fix wrong job name on Actions

### DIFF
--- a/.github/workflows/active-record-multi-tenant-tests.yml
+++ b/.github/workflows/active-record-multi-tenant-tests.yml
@@ -64,7 +64,7 @@ jobs:
           - '11'
           - '12'
 
-    name: Ruby ${{ matrix.ruby }}/${{ matrix.gemfile }} / Citus ${{ matrix.citus_version }}
+    name: Ruby ${{ matrix.ruby }}/${{ matrix.appraisal }} / Citus ${{ matrix.citus_version }}
     env:
        APPRAISAL: ${{ matrix.appraisal }}
        CITUS_VERSION: ${{ matrix.citus_version }}


### PR DESCRIPTION
As shown in https://github.com/citusdata/activerecord-multi-tenant/actions/runs/10526224060, the job names on Actions have been wrong since #182.

This fixes the job name of job matrix used on GitHub Actions.