### PR TITLE
Fix unintended side effects of delete_all and update_all with multi-tenancy for non-multi-tenant models

### DIFF
--- a/lib/activerecord-multi-tenant/relation_extension.rb
+++ b/lib/activerecord-multi-tenant/relation_extension.rb
@@ -4,8 +4,10 @@ module Arel
   module ActiveRecordRelationExtension
     # Overrides the delete_all method to include tenant scoping
     def delete_all
+      model = MultiTenant.multi_tenant_model_for_table(table_name)
+
       # Call the original delete_all method if the current tenant is identified by an ID
-      return super if MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
+      return super if model.nil? || MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
 
       stmt = Arel::DeleteManager.new.from(table)
       stmt.wheres = [generate_in_condition_subquery]
@@ -16,8 +18,10 @@ module Arel
 
     # Overrides the update_all method to include tenant scoping
     def update_all(updates)
+      model = MultiTenant.multi_tenant_model_for_table(table_name)
+
       # Call the original update_all method if the current tenant is identified by an ID
-      return super if MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
+      return super if model.nil? || MultiTenant.current_tenant_is_id? || MultiTenant.current_tenant.nil?
 
       stmt = Arel::UpdateManager.new
       stmt.table(table)

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -63,6 +63,11 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :name, :string
   end
 
+  create_table :unscoped_model_with_accounts, force: true do |t|
+    t.references :account, :integer
+    t.column :name, :string
+  end
+
   create_table :aliased_tasks, force: true, partition_key: :account_id do |t|
     t.column :account_id, :integer
     t.column :name, :string
@@ -206,6 +211,10 @@ end
 
 class UnscopedModel < ActiveRecord::Base
   validates_uniqueness_of :name
+end
+
+class UnscopedModelWithAccount < ActiveRecord::Base
+  belongs_to :account
 end
 
 class AliasedTask < ActiveRecord::Base


### PR DESCRIPTION
### Motivation / Background
The [Arel::ActiveRecordRelationExtension](https://github.com/a5-stable/activerecord-multi-tenant/blob/master/lib/activerecord-multi-tenant/relation_extension.rb) module is currently prepended directly to ActiveRecord::Relation, which can lead to unintended side effects for models that do not support multi-tenancy.

e.g.
```ruby
class PageView < ActiveRecord::Base
  multi_tenant :customer
  ...
end

class AnotherPageView < ActiveRecord::Base
  ...
end

# OK - works as expected
MultiTenant.with(customer) do
   PageView.all.delete_all
end
#=> DELETE FROM "page_views" WHERE "page_views"."id" IN (SELECT "page_views"."id" FROM "page_views" WHERE "page_views"."customer_id" = '1') AND "page_views"."customer_id" = '1'
```

But when running the same block for another model that doesn't support multi-tenancy:
```ruby
MultiTenant.with(customer) do
  AnotherPageView.all.delete_all
end

# Current Query
#=> DELETE FROM "another_page_views" WHERE "another_page_views"."id" IN (SELECT "another_page_views"."id" FROM "another_page_views" WHERE "another_page_views"."customer_id" = '1') AND "another_page_views"."customer_id" = '1'

# Ideal Query; The query should not add an additional customer_id condition since AnotherPageView does not support multi-tenancy.
#=> DELETE FROM "another_page_views" WHERE "another_page_views"."id"
```
This happens because the module is being prepended to all relations, even those that shouldn't be influenced by multi-tenancy.


### Solution
To fix this, we modified the code to call the original delete_all method when the model does not support multi-tenancy.