### PR TITLE
Fix SystemStackError when extending ActiveRecord::SchemaDumper#initialize with Module#prepend

### DIFF
--- a/lib/activerecord-multi-tenant/migrations.rb
+++ b/lib/activerecord-multi-tenant/migrations.rb
@@ -82,14 +82,12 @@ module MultiTenant
 end
 ActiveRecord::ConnectionAdapters::SchemaStatements.prepend(MultiTenant::SchemaStatementsExtensions)
 
-module ActiveRecord
-  class SchemaDumper
+module MultiTenant
+  module SchemaDumperExtensions
     private
 
-    alias initialize_without_citus initialize
-
     def initialize(connection, options = {})
-      initialize_without_citus(connection, options)
+      super
 
       citus_version =
         begin
@@ -114,10 +112,8 @@ module ActiveRecord
     end
 
     # Support for create_distributed_table & create_reference_table
-    alias table_without_citus table
-
     def table(table, stream)
-      table_without_citus(table, stream)
+      super
       table_name = remove_prefix_and_suffix(table)
       distribution_column = @distribution_columns[table_name]
       if distribution_column
@@ -128,5 +124,11 @@ module ActiveRecord
         stream.puts
       end
     end
+  end
+end
+
+module ActiveRecord
+  class SchemaDumper
+    prepend MultiTenant::SchemaDumperExtensions
   end
 end


### PR DESCRIPTION
Same issue as #216.

`strong_migrations` overrides `ActiveRecord::SchemaDumper#initialize` using `Module#prepend`, which caused a `SystemStackError` when used with `activerecord-multi-tenant`.

https://github.com/ankane/strong_migrations/blob/8e9baaa05c35fc9fdf206160c00b309c6e3a8bb6/lib/strong_migrations/schema_dumper.rb#L3-L7

Fix the issue by changing the `alias` in `activerecord-multi-tenant` to use `prepend`.