### PR TITLE
Add Rails 8.0 support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem 'activerecord-multi-tenant'
 
 ## Supported Rails versions
 
-All Ruby on Rails versions starting with 6.0 or newer (up to 7.0) are supported.
+All Ruby on Rails versions starting with 6.0 or newer (up to 8.0) are supported.
 
 This gem only supports ActiveRecord (the Rails default ORM), and not alternative ORMs like Sequel.
 


### PR DESCRIPTION
Rails 8.0 was supported in #260. Let’s update the README accordingly