### PR TITLE
Fixes issues with update_all, increment, and decrement

### DIFF
--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -63,6 +63,9 @@ describe 'Query Rewriter' do
       @queries.each do |actual_query|
         next unless actual_query.include?('UPDATE "projects" SET "name"')
 
+        # Extract parameterized values and replace placeholders
+        actual_query = actual_query.gsub('$1', "'New Name'")
+
         expect(format_sql(actual_query)).to eq(format_sql(expected_query.gsub(':account_id', account.id.to_s)))
       end
     end
@@ -98,6 +101,9 @@ describe 'Query Rewriter' do
 
       @queries.each do |actual_query|
         next unless actual_query.include?('UPDATE "projects" SET "name"')
+
+        # Extract parameterized values and replace placeholders
+        actual_query = actual_query.gsub('$1', "'#{new_name}'").gsub('$2', limit.to_s)
 
         expect(format_sql(actual_query.gsub('$1',
                                             limit.to_s)).strip).to eq(format_sql(expected_query).strip)
@@ -243,6 +249,43 @@ describe 'Query Rewriter' do
           Page.joins(:domain).pluck(:id)
         end
       ).to eq([page_in_alive_domain.id])
+    end
+  end
+
+  context 'when updating locked column in comments' do
+    let!(:account) { Account.create!(name: 'Test Account') }
+    let!(:comment1) { Comment.create!(account_id: account.id, commentable_id: 1, commentable_type: 'Post') }
+    let!(:comment2) { Comment.create!(account_id: account.id, commentable_id: 2, commentable_type: 'Post') }
+
+    it 'updates the locked column for all records' do
+      expect do
+        Comment.update_all(locked: 1)
+      end.to change { Comment.where(locked: 1).count }.from(0).to(2)
+    end
+
+    it 'update_all the records with expected query' do
+      expected_query = <<-SQL.strip
+        UPDATE "comments" SET "locked" = 1 WHERE "comments"."id" IN
+          (SELECT "comments"."id" FROM "comments"
+              WHERE "comments"."account_id" = :account_id
+          )
+          AND "comments"."account_id" = :account_id
+      SQL
+
+      expect do
+        MultiTenant.with(account) do
+          Comment.update_all(locked: 1)
+        end
+      end.to change { Comment.where(locked: 1).count }.from(0).to(2)
+
+      @queries.each do |actual_query|
+        next unless actual_query.include?('UPDATE "comments" SET "locked"')
+
+        # Extract parameterized values and replace placeholders
+        actual_query = actual_query.gsub('$1', '1')
+
+        expect(format_sql(actual_query)).to eq(format_sql(expected_query.gsub(':account_id', account.id.to_s)))
+      end
     end
   end
 end

--- a/spec/activerecord-multi-tenant/query_rewriter_spec.rb
+++ b/spec/activerecord-multi-tenant/query_rewriter_spec.rb
@@ -288,4 +288,17 @@ describe 'Query Rewriter' do
       end
     end
   end
+
+  context 'when using decrement or increment' do
+    let!(:account) { Account.create!(name: 'Test Account') }
+    let!(:comment) { Comment.create!(account_id: account.id, commentable_id: 1, commentable_type: 'Post', locked: 1) }
+
+    it 'increments and decrements the column `locked`' do
+      expect do
+        comment.increment!(:locked)
+        comment.increment!(:locked)
+        comment.decrement!(:locked)
+      end.to change { comment.reload.locked }.from(1).to(2)
+    end
+  end
 end

--- a/spec/schema.rb
+++ b/spec/schema.rb
@@ -78,6 +78,7 @@ ARGV.grep(/\w+_spec\.rb/).empty? && ActiveRecord::Schema.define(version: 1) do
     t.column :account_id, :integer
     t.column :commentable_id, :integer
     t.column :commentable_type, :string
+    t.column :locked, :integer, default: 0
   end
 
   create_table :partition_key_not_model_tasks, force: true, partition_key: :non_model_id do |t|


### PR DESCRIPTION
Hi all, I'm well aware that this gem is abandoned, yet I'm submitting this PR in case someone runs into the same problem as me and comes here to the PRs section looking for answers.

This upstream PR https://github.com/citusdata/activerecord-multi-tenant/pull/223 broke some usages of update_all. Both increment and decrement use update_all.

For example a call to `model.decrement!(:counter)` generates an UPDATE query with `SET "counter" = NULL` instead of the correct `SET "counter" = COALESCE("counter", 0)`.

@Laykou first noticed this problem https://github.com/citusdata/activerecord-multi-tenant/pull/223/files#r1743665204 and @Amit909Singh mentioned they fixed it in https://github.com/citusdata/activerecord-multi-tenant/pull/223#issuecomment-2357832777.

In this PR, I cherry-picked his commit https://github.com/Amit909Singh/activerecord-multi-tenant/commit/c08b636eb14c39f490f40b36ba86dd33e8c4bf03 and added tests for the `increment` and `decrement` cases.

All tests are passing for Rails/ActiveRecord versions 7.0, 7.1, 7.2, and 8.0.
The tests are failing for 6.0 and 6.1, but I didn't care much since they are old versions.
The tests are also failing for 8.1, I didn't look into it either since I'm still on 7.2.

I ran the tests manually instead of using Github actions, like so:

```bash
# 1. Start postgres and citus
docker-compose up -d
# or if you want to specify the citus version
CITUS_VERSION=12.1.6 docker-compose up -d

# 2. Install dependencies for all versions of Rails and ActiveRecord:
bundle exec appraisal install

# 3. Run tests
# run test suite with all versions of Rails and ActiveRecord:
bundle exec appraisal rspec

# or run a specific version of Rails or ActiveRecord:
# (see `Appraisals` file for available versions)
bundle exec appraisal rails-7.2 rspec
```