### PR TITLE
Rails v8からArel::Nodes::Function#aliasメソッドが削除されたため修正

### DIFF
--- a/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
+++ b/lib/activerecord-multi-tenant/arel_visitors_depth_first.rb
@@ -39,7 +39,6 @@ module MultiTenant
 
     def function(obj)
       visit obj.expressions
-      visit obj.alias
       visit obj.distinct
     end
     alias visit_Arel_Nodes_Avg    function
@@ -54,12 +53,10 @@ module MultiTenant
       visit obj.name
       visit obj.expressions
       visit obj.distinct
-      visit obj.alias
     end
 
     def visit_Arel_Nodes_Count(obj)
       visit obj.expressions
-      visit obj.alias
       visit obj.distinct
     end
 


### PR DESCRIPTION
TASK-5740の関連。

uuuo-webをRails v8にアップグレードを実施したが、v8ではArel::Nodes::Function#aliasメソッドが削除されている。

activerecord-multi-tenantで参照している箇所が、Nomethodエラーとなっているので修正する。

fork元にもPRが出ているが、まだマージされていない。
https://github.com/citusdata/activerecord-multi-tenant/pull/284

